### PR TITLE
Avoid appending empty tokens

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -10,7 +10,7 @@ impl Tokens {
     }
 
     pub fn append(&mut self, token: &str) {
-        if !self.0.is_empty() {
+        if !self.0.is_empty() && !token.is_empty() {
             self.0.push(' ');
         }
         self.0.push_str(token);


### PR DESCRIPTION
This is useful as it eliminates extra spaces which are created when
appending an empty Tokens object with `to_tokens()`.