### PR TITLE
Add Ident.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote"
-version = "0.3.8" # don't forget to update version in readme
+version = "0.3.9" # don't forget to update version in readme
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Quasi-quoting macro quote!(...)"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quasi-quoting without a Syntex dependency, intended for use with [Macros
 
 ```toml
 [dependencies]
-quote = "0.3"
+quote = "0.3.9"
 ```
 
 ```rust

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,0 +1,56 @@
+use {Tokens, ToTokens};
+use std::borrow::Cow;
+use std::fmt;
+
+#[derive(Debug, Clone, Eq, Hash)]
+pub struct Ident(String);
+
+impl Ident {
+    pub fn new<T: Into<Ident>>(t: T) -> Self {
+        t.into()
+    }
+}
+
+impl<'a> From<&'a str> for Ident {
+    fn from(s: &str) -> Self {
+        Ident(s.to_owned())
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Ident {
+    fn from(s: Cow<'a, str>) -> Self {
+        Ident(s.into_owned())
+    }
+}
+
+impl From<String> for Ident {
+    fn from(s: String) -> Self {
+        Ident(s)
+    }
+}
+
+impl AsRef<str> for Ident {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Ident {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(formatter)
+    }
+}
+
+impl<T: ?Sized> PartialEq<T> for Ident
+    where T: AsRef<str>
+{
+    fn eq(&self, other: &T) -> bool {
+        self.0 == other.as_ref()
+    }
+}
+
+impl ToTokens for Ident {
+    fn to_tokens(&self, tokens: &mut Tokens) {
+        tokens.append(self.as_ref())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@ pub use tokens::Tokens;
 mod to_tokens;
 pub use to_tokens::{ToTokens, ByteStr};
 
+mod ident;
+pub use ident::Ident;
+
 /// The whole point.
 #[macro_export]
 macro_rules! quote {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -193,6 +193,15 @@ fn test_byte_str() {
 }
 
 #[test]
+fn test_ident() {
+    let foo = quote::Ident::from("Foo");
+    let bar = quote::Ident::from(format!("Bar{}", 7));
+    let tokens = quote!(struct #foo; enum #bar {});
+    let expected = "struct Foo ; enum Bar7 { }";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
 fn test_duplicate() {
     let ch = 'x';
 


### PR DESCRIPTION
When using quote without syn to generate code in a build script, this is useful to synthesize identifiers in the generated code.

(Quoting &str or String produces a string literal.)