### PR TITLE
Implement ToTokens as literals for arrays, tuples, slices, and Vec.

### DIFF
--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -162,3 +162,165 @@ macro_rules! impl_to_tokens_floating {
 }
 impl_to_tokens_floating!(f32);
 impl_to_tokens_floating!(f64);
+
+impl<T: ToTokens> ToTokens for [T] {
+    fn to_tokens(&self, tokens: &mut Tokens) {
+        tokens.append("[");
+        for item in self {
+            item.to_tokens(tokens);
+            tokens.append(",");
+        }
+        tokens.append("]");
+    }
+}
+
+impl<T: ToTokens> ToTokens for Vec<T> {
+    fn to_tokens(&self, tokens: &mut Tokens) {
+        self[..].to_tokens(tokens)
+    }
+}
+
+macro_rules! array_impls {
+    ($($N:expr)+) => {
+        $(
+            impl<T: ToTokens> ToTokens for [T; $N] {
+                fn to_tokens(&self, tokens: &mut Tokens) {
+                    self[..].to_tokens(tokens)
+                }
+            }
+        )+
+    }
+}
+
+array_impls! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
+}
+
+macro_rules! tuple_impls {
+    ($(
+        $Tuple:ident {
+            $(($idx:tt) -> $T:ident)+
+        }
+    )+) => {
+        $(
+            impl<$($T: ToTokens),+> ToTokens for ($($T,)+) {
+                fn to_tokens(&self, tokens: &mut Tokens) {
+                    tokens.append("(");
+                    $(
+                        self.$idx.to_tokens(tokens);
+                        tokens.append(",");
+                    )+
+                    tokens.append(")");
+                }
+            }
+        )+
+    }
+}
+
+tuple_impls! {
+    Tuple1 {
+        (0) -> A
+    }
+    Tuple2 {
+        (0) -> A
+        (1) -> B
+    }
+    Tuple3 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+    }
+    Tuple4 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+    }
+    Tuple5 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+    }
+    Tuple6 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+    }
+    Tuple7 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+        (6) -> G
+    }
+    Tuple8 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+        (6) -> G
+        (7) -> H
+    }
+    Tuple9 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+        (6) -> G
+        (7) -> H
+        (8) -> I
+    }
+    Tuple10 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+        (6) -> G
+        (7) -> H
+        (8) -> I
+        (9) -> J
+    }
+    Tuple11 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+        (6) -> G
+        (7) -> H
+        (8) -> I
+        (9) -> J
+        (10) -> K
+    }
+    Tuple12 {
+        (0) -> A
+        (1) -> B
+        (2) -> C
+        (3) -> D
+        (4) -> E
+        (5) -> F
+        (6) -> G
+        (7) -> H
+        (8) -> I
+        (9) -> J
+        (10) -> K
+        (11) -> L
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -109,6 +109,38 @@ fn test_advanced() {
 }
 
 #[test]
+fn test_tuple() {
+    let x = ("foo", 4_u32);
+    let tokens = quote!(#x);
+    let expected = "( \"foo\" , 4u32 , )";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_array() {
+    let x: [u32; 3] = [1, 2, 3];
+    let tokens = quote!(#x);
+    let expected = "[ 1u32 , 2u32 , 3u32 , ]";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_slice() {
+    let x: &[u32] = &[1, 2, 3];
+    let tokens = quote!(&#x);  // Note: explicit `&`
+    let expected = "& [ 1u32 , 2u32 , 3u32 , ]";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_vec() {
+    let x: Vec<u32> = vec![1, 2, 3];
+    let tokens = quote!(vec!#x);  // Note: explicit `vec!`
+    let expected = "vec ! [ 1u32 , 2u32 , 3u32 , ]";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
 fn test_integer() {
     let ii8 = -1i8;
     let ii16 = -1i16;


### PR DESCRIPTION
This is consistent with the existing impls for String and str that produce string literal syntax.

Slices and Vec use array literal syntax, a `&` or `vec!` prefix needs to be added explicitly.

Arrays and tuples have impls up to 32 and 12 members, respectively. This uses the same macros to generate impls as `libcore` does internally.