### PR TITLE
Add a Hex wrapper for integer type, with a ToTokens impl using `{:X}`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ mod tokens;
 pub use tokens::Tokens;
 
 mod to_tokens;
-pub use to_tokens::{ToTokens, ByteStr};
+pub use to_tokens::{ToTokens, ByteStr, Hex};
 
 /// The whole point.
 #[macro_export]

--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -105,11 +105,21 @@ macro_rules! impl_to_tokens_display {
 impl_to_tokens_display!(Tokens);
 impl_to_tokens_display!(bool);
 
+/// Wrap an integer so it interpolates as a hexadecimal.
+#[derive(Debug)]
+pub struct Hex<T>(pub T);
+
 macro_rules! impl_to_tokens_integer {
     ($ty:ty) => {
         impl ToTokens for $ty {
             fn to_tokens(&self, tokens: &mut Tokens) {
                 tokens.append(&format!(concat!("{}", stringify!($ty)), self));
+            }
+        }
+
+        impl ToTokens for Hex<$ty> {
+            fn to_tokens(&self, tokens: &mut Tokens) {
+                tokens.append(&format!(concat!("0x{:X}", stringify!($ty)), self.0));
             }
         }
     };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -130,6 +130,14 @@ fn test_integer() {
 }
 
 #[test]
+fn test_hex() {
+    let hex = quote::Hex(0xFFFF_0000_u32);
+    let tokens = quote!(#hex);
+    let expected = "0xFFFF0000u32";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
 fn test_floating() {
     let e32 = 2.71828f32;
     let nan32 = f32::NAN;


### PR DESCRIPTION
This doesn’t make a difference when rustc is parsing generated code, but sometimes humans need to look at that code for debugging and bit-packed values are much more readable in hexadecimal than decimal.