### PR TITLE
Add Tokens::into_string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote"
-version = "0.3.13" # don't forget to update version in readme for breaking changes
+version = "0.3.14" # don't forget to update version in readme for breaking changes
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Quasi-quoting macro quote!(...)"

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -132,6 +132,10 @@ impl Tokens {
         &self.0
     }
 
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
     pub fn parse<T: FromStr>(&self) -> Result<T, T::Err> {
         FromStr::from_str(&self.0)
     }


### PR DESCRIPTION
Tokens::as_str doesn’t work for returning the contents of a `Tokens` created in that function.