### PR TITLE
computation in interpolation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,19 @@
 //! return quote! { /* ... */ #t /* ... */ };
 //! ```
 //!
+//! You can use `#{...}` for arbitrary computations inside of quotations - _the result_ will then
+//! be spliced into the token stream:
+//!
+//! - `#{a[0]}` - index arrays
+//! - `#{x.foo}` - access fields
+//! - `#{format!("{:?}", ::std::time::Instant::now())}` - arbitrary computations and nested macros,
+//!    which are valid Rust
+//!
+//! Note:
+//! - interpolation inside of `#foo` inside of `#{...}` is disabled by design. `#{#foo}` is
+//!   illegal, but on the other hand you can `#{quote!(#foo)}` (if you _really want to_).
+//! - computations `#{...}` _inside_ of repetitions `#(...)*` are evaluated each time.
+//!
 //! Call `to_string()` or `as_str()` on a Tokens to get a `String` or `&str` of Rust
 //! code.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,8 +98,8 @@ macro_rules! pounded_var_names {
         pounded_var_names!($finish ($($found)*) $($inner)* $($rest)*)
     };
 
-    ($finish:ident ($($found:ident)*) # { $($inner:tt)* } $($rest:tt)*) => {
-        pounded_var_names!($finish ($($found)*) $($inner)* $($rest)*)
+    ($finish:ident ($($found:ident)*) # { $($ignore:tt)* } $($rest:tt)*) => {
+        pounded_var_names!($finish ($($found)*) $($rest)*)
     };
 
     ($finish:ident ($($found:ident)*) # $first:ident $($rest:tt)*) => {
@@ -216,6 +216,11 @@ macro_rules! quote_each_token {
         $tokens.append("[");
         quote_each_token!($tokens $($inner)*);
         $tokens.append("]");
+        quote_each_token!($tokens $($rest)*);
+    };
+
+    ($tokens:ident # { $($inner:tt)* } $($rest:tt)*) => {
+        $crate::ToTokens::to_tokens(&{ $($inner)* }, &mut $tokens);
         quote_each_token!($tokens $($rest)*);
     };
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -96,6 +96,8 @@ fn test_complex_computation_in_loop() {
     );
 
     let expected = r#""1" , "e" , "+" , "a" , "2" , "e" , "+" , "a" , "3" , "e" , "+" , "a" ,"#;
+
+    assert_eq!(expected, tokens.as_str());
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -34,6 +34,73 @@ fn test_quote_impl() {
 }
 
 #[test]
+fn test_simple_computation_in_interpolation() {
+    let foo: [u32; 3] = [0, 1, 42];
+    let tokens = quote!(#{foo[2]});
+
+    let expected = "42u32";
+
+    assert_eq!(expected, tokens.as_str());
+}
+
+#[test]
+fn test_complex_computation_in_interpolation() {
+    let tokens = quote!(
+        let #{
+            struct Foo { }
+
+            impl quote::ToTokens for Foo {
+                fn to_tokens(&self, tokens: &mut quote::Tokens) {
+                    tokens.append("foo")
+                }
+            }
+
+            Foo { }
+        } = #{ quote!("Hello World!") };
+    );
+
+    let expected = "let foo = \"Hello World!\" ;";
+
+    assert_eq!(expected, tokens.as_str());
+}
+
+#[test]
+fn test_simple_computation_in_loop() {
+    let foo: [&'static str; 3] = ["1", "2", "3"];
+    let iter = foo.iter();
+    let tokens = quote!(#( #iter, #{"+"}, )*);
+
+    let expected = r#""1" , "+" , "2" , "+" , "3" , "+" ,"#;
+
+    assert_eq!(expected, tokens.as_str());
+}
+
+#[test]
+fn test_complex_computation_in_loop() {
+    let foo: [&'static str; 3] = ["1", "2", "3"];
+    let iter = foo.iter();
+    let tokens = quote!(
+        #( // loop
+            #{ // interpolation
+                "this will be ignored because the outer loop is empty"
+            }
+        )*
+        #( // loop
+            #iter,
+            #{ // interpolation
+                let foo = ["e", "+", "a"];
+                let iter = foo.iter();
+                quote!( #(#iter),*, )
+            }
+        )*
+    );
+
+    let expected = r#""1" , "e" , "+" , "a" , "2" , "e" , "+" , "a" , "3" , "e" , "+" , "a" ,"#;
+
+    assert_eq!(expected, tokens.as_str());
+}
+
+#[test]
 fn test_substitution() {
     let x = X;
     let tokens = quote!(#x <#x> (#x) [#x] {#x});


### PR DESCRIPTION
implement #10

The design principle is very simple, e.g. `quote!(A #{ B } C)` will expand to

```rust
let tokens = Tokens::new();
tokens.append(A);
tokens.append({B});
tokens.append(C);
```

Here `{ B }` can be any valid Rust code block as long as its result implements `ToTokens`.

This simple implementation just _ignores_ all quote-variables `#x` in `B`. Therefore `#{ B }` will just behave like a black box inside of e.g. a loop.

This black-box behaviour theoretically allows to nest a `quote!(#x)` or other macros inside of interpolation blocks and allows for "local reasoning" about the meaning of some tokens. Whether deep nesting would be good practice is on a different page.

To answer the [design questions](https://github.com/dtolnay/quote/issues/10#issuecomment-252517479)

1. A computation inside of a repetition is just treated as a constant expression! Something like `quote! { #( #{...} )* }` will therefore evaluate to zero tokens, because the loop does not find any iterator. If `#{...}` evaluates to an iterator you still need to bind the result to a variable first and loop over that. Sorry. (*)
2. The heuristic to find loop variables _ignores_ the inside of interpolation blocks.
3. No limit on what computation supports.

(*) In theory we could try to interpret `#{...}` in loops as iterators, as we do with any `#foo`. But we will lack a proper identifier for `#{...}`, since the current macro_rules system does not allow generation of identifiers like `__my_local_iterator_005`. We could implement a helper macro with a global state (yes that is possible via higher order macros) like `pop_iterator_ident()`. The problem with that is, that it will only support a finite amount of calls until the supply is exhausted. I'd say we circumvent that trouble and don't support this pattern until Rust support generation of identifiers in macros.