### PR TITLE
Add implementation for std::iter::Sum

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,5 +1,6 @@
 use super::ToTokens;
 use std::fmt::{self, Display};
+use std::iter::Sum;
 use std::str::FromStr;
 
 /// Tokens produced by a `quote!(...)` invocation.
@@ -152,5 +153,15 @@ impl Display for Tokens {
 impl AsRef<str> for Tokens {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+impl<T: ToTokens> Sum<T> for Tokens {
+    fn sum<I>(iter: I) -> Self
+        where I: Iterator<Item=T> {
+        iter.fold(Tokens::default(), |mut tokens, token| {
+            token.to_tokens(&mut tokens);
+            tokens
+        })
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -358,3 +358,25 @@ fn test_closure() {
     let tokens = quote! { #(#fields)* };
     assert_eq!("__field0 __field1 __field2", tokens.as_str());
 }
+
+#[test]
+fn test_sum() {
+    use quote::{Tokens, ToTokens};
+
+    #[derive(Default, Clone, Copy)]
+    struct SomeT { val: usize };
+    impl SomeT {
+        fn new(val: usize) -> SomeT {
+            SomeT { val: val }
+        }
+    }
+    impl ToTokens for SomeT {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            tokens.append(format!("__t{}", self.val));
+        }
+    }
+
+    let items: Vec<_> = (0..3).map(SomeT::new).collect();
+    let tokens: Tokens = items.into_iter().sum();
+    assert_eq!("__t0 __t1 __t2", tokens.as_str());
+}


### PR DESCRIPTION
This is useful when combining multiple items which implements `quote::ToTokens`, as follows:

```rust
struct SomeT { ... }
impl ToTokens for SomeT { ... }

let items: Vec<SomeT> = generate_some_t_items();
let body: Tokens = items().into_iter().sum();
```
