### PR TITLE
restricted computation in implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,17 @@ sudo: false
 language: rust
 
 rust:
-  - nightly
   - stable
   - 1.12.1
   - 1.13.0
   - beta
+matrix:
+  include:
+    - rust: nightly
+      env: CARGO_FEATURES=dev_nightly # enable compiletests
+env:
+  global:
+  - CARGO_FEATURES=""
 
 script:
-  - cargo test
+  - cargo test --features "$CARGO_FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ repository = "https://github.com/dtolnay/quote"
 documentation = "https://docs.rs/quote/"
 keywords = ["syn"]
 include = ["Cargo.toml", "src/**/*.rs", "tests/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+[features]
+dev_nightly = ["compiletest_rs"]
+[dependencies]
+compiletest_rs = { version = "0.2", optional = true }

--- a/tests/compile-fail/deny-closures.rs
+++ b/tests/compile-fail/deny-closures.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate quote;
+
+fn main() {
+    quote!(
+        #{ foo.map(|x| &x) }
+        //~^ ERROR no rules expected the token `(`
+    );
+}

--- a/tests/compile-fail/deny-macros.rs
+++ b/tests/compile-fail/deny-macros.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate quote;
+
+fn main() {
+    quote!(
+        #{ format!("Hello {}!", "world") }
+        //~^ ERROR no rules expected the token `!`
+    );
+}

--- a/tests/compile-fail/deny-numbers.rs
+++ b/tests/compile-fail/deny-numbers.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate quote;
+
+fn main() {
+    quote!(
+        #{ 2*3*6 }
+        //~^ ERROR expected ident, found 2
+    );
+}

--- a/tests/compile-fail/deny-plus.rs
+++ b/tests/compile-fail/deny-plus.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate quote;
+
+fn main() {
+    quote!(
+        #{ a+b }
+        //~^ ERROR no rules expected the token `+`
+    );
+}

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "dev_nightly")]
+extern crate compiletest_rs as compiletest;
+
+// note:
+// - `env::var("PROFILE")` is only available vor build scripts
+//   http://doc.crates.io/environment-variables.html
+const PROFILE: &'static str = "debug";
+
+use std::env;
+use std::path::PathBuf;
+
+fn run_mode(mode: &'static str) {
+    let base_dir = env!("CARGO_MANIFEST_DIR");
+    let test_dir = PathBuf::from(format!("{}/tests/{}", base_dir, mode));
+
+    if test_dir.is_dir() {
+        let mut config = compiletest::default_config();
+        let cfg_mode = mode.parse().ok().expect("Invalid mode");
+
+        config.mode = cfg_mode;
+        config.src_base = test_dir;
+
+        // note:
+        // - cargo respects the environment variable `env::var("CARGO_TARGET_DIR")`,
+        //   however if this is not set and a virtual manifest is used, we will *not*
+        //   know the path :-(
+        // In that case try to set `CARGO_TARGET_DIR` manually.
+        let build_dir = env::var("CARGO_TARGET_DIR").unwrap_or(base_dir.to_string());
+        let artefacts_dir = format!("{}/target/{}", build_dir, PROFILE);
+
+        config.target_rustcflags =
+            Some(format!("-L {} -L {}/deps", artefacts_dir, artefacts_dir));
+
+        compiletest::run_tests(&config);
+    }
+}
+
+#[test]
+fn compile_test() {
+    run_mode("run-pass");
+    run_mode("run-fail");
+    run_mode("compile-fail");
+}

--- a/tests/computation.rs
+++ b/tests/computation.rs
@@ -1,0 +1,134 @@
+#[macro_use]
+extern crate quote;
+
+pub use quote::Tokens;
+
+pub struct SimpleStruct1D<T> {
+    x: T,
+}
+
+pub struct SimpleStruct2D<T> {
+    x: T,
+    y: T,
+}
+
+mod simple {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn array_access() {
+        let a = [quote!(zero), quote!(one)];
+        let b = [&a, &a];
+        let tokens = quote!(#{a[0]} - #{a[1]} - #{b[1][0]} - #{b[0][1]});
+
+        assert_eq!(tokens, quote!(
+            zero - one - zero - one
+        ));
+    }
+
+    #[test]
+    fn tuple_access() {
+        let a = (quote!(zero), quote!(one));
+        let b = (&a, &a);
+        let tokens = quote!(#{a.0} - #{a.1} - #{(b.1).0} - #{(b.0).1});
+
+        assert_eq!(tokens, quote!(
+            zero - one - zero - one
+        ));
+    }
+
+    #[test]
+    fn struct_access() {
+        let a = SimpleStruct2D {
+            x: quote!(zero),
+            y: quote!(one),
+        };
+        let b = SimpleStruct2D {
+            x: &a,
+            y: &a,
+        };
+        let tokens = quote!(#{a.x} - #{a.y} - #{b.y.x} - #{b.x.y});
+
+        assert_eq!(tokens, quote!(
+            zero - one - zero - one
+        ));
+    }
+
+    #[test]
+    fn function_call() {
+        let a = || { quote!(Lorem) };
+        let b = (&a,);
+        let c = [&a];
+        let tokens = quote!(#{a()} - #{(b.0)()} - #{c[0]()});
+
+        assert_eq!(tokens, quote!(
+            Lorem - Lorem - Lorem
+        ));
+    }
+}
+
+mod mixed {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn leading_array_access() {
+        let tuple = [(quote!(tuple),)];
+        let strukt = [SimpleStruct1D { x: quote!(struct) }];
+        let func = [|| { quote!(func) }];
+        let tokens = quote!(#{tuple[0].0} - #{strukt[0].x} - #{func[0]()});
+
+        assert_eq!(tokens, quote!(
+            tuple - struct - func
+        ));
+    }
+
+    #[test]
+    fn leading_tuple_access() {
+        let strukt = (SimpleStruct1D { x: quote!(struct) },);
+        let func = (|| { quote!(func) },);
+        let array = ([quote!(array)],);
+        let tokens = quote!(#{(strukt.0).x} - #{(func.0)()} - #{(array.0)[0]});
+
+        assert_eq!(tokens, quote!(
+            struct - func - array
+        ));
+    }
+
+    #[test]
+    fn leading_struct_access() {
+        struct MixedStruct {
+            array: Vec<Tokens>,
+            tuple: (Tokens,),
+        }
+
+        impl MixedStruct {
+            fn func(&self) -> Tokens {
+                quote!(func)
+            }
+        }
+
+        let a = MixedStruct {
+            array: vec![quote!(array)],
+            tuple: (quote!(tuple),),
+        };
+        let tokens = quote!(#{a.func()} - #{a.array[0]} - #{a.tuple.0});
+
+        assert_eq!(tokens, quote!(
+            func - array - tuple
+        ));
+    }
+
+    #[test]
+    fn leading_function_call() {
+        let array = || { [quote!(array)] };
+        let tuple = || { (quote!(tuple),) };
+        let strukt = || { SimpleStruct1D { x: quote!(struct) } };
+        let tokens = quote!(#{array()[0]} - #{tuple().0} - #{strukt().x});
+
+        assert_eq!(tokens, quote!(
+            array - tuple - struct
+        ));
+    }
+}


### PR DESCRIPTION
Follow-up on #30 to implement #10. This is the proposed documentation of the feature:

> You can use `#{...}` for some basic computations inside of quotations. Computations are
> restricted to combinations of:
> 
> - `#{x[0]}` - index arrays with integers 0..32
> - `#{x.0}` - index tuple structs with integers 0..32
> - `#{x.foo}` - access fields
> - `#{x()}` - call functions (without arguments)
> 
> Note:
> - Any chained combination of the above is also possible, like `#{self.foo[0].bar()}`.
>   But please consider replacing too complex computations with helper variables `#bar`
>   in order to improve the readability for other people - thank you in advance. ;-)
> - These computations can be particularly useful if you want to implement `quote::ToTokens`
>   for a custom struct. You can then reference the struct fields directly via `#{self.foo}`
>   etc.
> - computations `#{...}` _inside_ of repetitions `#(...)*` are treated as constant expressions
>   and are not iterated over - in contrast to any other `#x` inside of a repetition.

I have added some [`compiletests`](https://github.com/laumann/compiletest-rs) which assert that more powerful computations are [indeed rejected](https://travis-ci.org/colin-kiegel/quote/jobs/212726496#L174-L188).

The restriction is isolated in a little helper macro [here](https://github.com/dtolnay/quote/compare/master...colin-kiegel:feature/restricted_computation_in_interpolation?expand=1#diff-b4aea3e418ccdb71239b96952d9cddb6R209).