### PR TITLE
Add `ToTokens::into_tokens` to conveniently convert `ToTokens` into `Tokens`

### DIFF
--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -27,6 +27,16 @@ pub trait ToTokens {
     /// }
     /// ```
     fn to_tokens(&self, &mut Tokens);
+
+    /// Convert `self` directly into a `Tokens` object.
+    ///
+    /// This method is implicitly implemented using `to_tokens`, and acts as a
+    /// convenience method for consumers of the `ToTokens` trait.
+    fn into_tokens(self) -> Tokens where Self: Sized {
+        let mut tokens = Tokens::new();
+        self.to_tokens(&mut tokens);
+        tokens
+    }
 }
 
 impl<'a, T: ?Sized + ToTokens> ToTokens for &'a T {
@@ -122,8 +132,17 @@ macro_rules! impl_to_tokens_display {
     };
 }
 
-impl_to_tokens_display!(Tokens);
 impl_to_tokens_display!(bool);
+
+impl ToTokens for Tokens {
+    fn to_tokens(&self, tokens: &mut Tokens) {
+        tokens.append(self.as_str());
+    }
+
+    fn into_tokens(self) -> Tokens {
+        self
+    }
+}
 
 /// Wrap an integer so it interpolates as a hexadecimal.
 #[derive(Debug)]

--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -122,17 +122,11 @@ impl<'a> ToTokens for ByteStr<'a> {
     }
 }
 
-macro_rules! impl_to_tokens_display {
-    ($ty:ty) => {
-        impl ToTokens for $ty {
-            fn to_tokens(&self, tokens: &mut Tokens) {
-                tokens.append(&self.to_string());
-            }
-        }
-    };
+impl ToTokens for bool {
+    fn to_tokens(&self, tokens: &mut Tokens) {
+        tokens.append(if *self { "true" } else { "false" });
+    }
 }
-
-impl_to_tokens_display!(bool);
 
 impl ToTokens for Tokens {
     fn to_tokens(&self, tokens: &mut Tokens) {


### PR DESCRIPTION
I find myself when writing generic helper code for `syn` and `quote` often reaching for this odd pattern to convert a `T: ToTokens` return value from a lambda or argument into an actual `Tokens` object:

```
needs_tokens({
    let mut t = Tokens::new();
    some_to_tokens_source().to_tokens(&mut t);
    t
})
```

In many situations where `some_to_tokens_source` is an identifier I can write:

```
needs_tokens(quote!(#some_to_tokens_source))
```

But it would be nice to add a defaulted method to `ToTokens`, which could be implemented on `Tokens` and other types which can be converted cheaply to `String` objects as a direct into conversion.

This patch also improves the performance of `ToTokens::to_tokens` on `Tokens` by avoiding an unnecessary intermediate allocation caused by the use of `impl_to_tokens_display!` for `Tokens`.