### PR TITLE
Special case ident tokens in the quote_each_token macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,8 +268,17 @@ macro_rules! quote_each_token {
         quote_each_token!($tokens $($rest)*);
     };
 
+    // Special case for `ident` tokens.
+    ($tokens:ident $first_ident:ident $($rest:tt)*) => {
+        $crate::_rt::append_kind(&mut $tokens,
+            $crate::_rt::TokenKind::Word(
+                stringify!($first_ident).into()));
+        quote_each_token!($tokens $($rest)*);
+    };
+
+    // We can't identify any other token types reliably, so we just have to grab
+    // the `tt`, and parse it at runtime.
     ($tokens:ident $first:tt $($rest:tt)*) => {
-        // TODO: this seems slow... special case some `:tt` arguments?
         $crate::__rt::parse(&mut $tokens, stringify!($first));
         quote_each_token!($tokens $($rest)*);
     };


### PR DESCRIPTION
This is a partial fix to #38. It only special cases ident tokens, because they're easy to parse in a macro_rules! macro.

My only other idea would be to add some cases for literals, which are single-tt non-paren expressions, such as:

```rust
// Repeat something like this (this is untested code) 
// for each of the symbols in expr::follow
    ($tokens:ident $first:expr => $($rest:tt)*) => {
        quote_expr_tokens!($tokens $first);
        $crate::_rt::append_kind(&mut $tokens,
            $crate::_rt::TokenKind::Op('=', $crate::_rt::OpKind::Joint));
        $crate::_rt::append_kind(&mut $tokens,
            $crate::_rt::TokenKind::Op('>', $crate::_rt::OpKind::Alone));
        quote_each_token!($tokens $($rest)*);
    };

// And add quote_expr_tokens (again untested)
macro_rules! quote_expr_tokens {
    ($tokens: ident $tt: tt) => {
        // YUS! we got a single-tokentree expression! 
        // As we already parsed delimited sequences, I _think_ this should be a literal.
        $crate::_rt::append_kind(&mut $tokens,
            $crate::_rt::TokenKind::Literal(stringify!($tt).into()));
    };
    ($tokens: ident $first:tt $($rest:tt)+) => {
        // Oh no! We got a lot of tts, fall back to our old cide
        $crate::__rt::parse(&mut $tokens, stringify!($first));
        quote_each_token!($tokens $($rest)*);
    };
};
```

And beyond that, we could add all of the symbols we can think of as individual options.

That's a much bigger change than the current implementation. @alexcrichton and @dtolnay, do you think doing things like that would be worthwhile, and also are there other expressions which are a single tt wide which are not a literal?