### PR TITLE
Add proc-macro feature to control the runtime dependency on rustc toolchain libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ rust:
 
 script:
   - cargo test
+  - cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,10 @@ keywords = ["syn"]
 include = ["Cargo.toml", "src/**/*.rs", "tests/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [dependencies]
-proc-macro2 = "0.3"
+proc-macro2 = { version = "0.3", default-features = false }
+
+[features]
+default = ["proc-macro"]
+# Disabling the proc-macro feature removes the dynamic library dependency on
+# libproc_macro in the rustc compiler.
+proc-macro = ["proc-macro2/proc-macro"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@
 #![doc(html_root_url = "https://docs.rs/quote/0.4.2")]
 
 extern crate proc_macro2;
+#[cfg(feature = "proc-macro")]
 extern crate proc_macro;
 
 mod tokens;
@@ -161,7 +162,10 @@ pub mod __rt {
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "proc-macro")]
 /// extern crate proc_macro;
+/// # #[cfg(not(feature = "proc-macro"))]
+/// # extern crate proc_macro2 as proc_macro;
 ///
 /// #[macro_use]
 /// extern crate quote;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -2,6 +2,7 @@ use super::ToTokens;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 
+#[cfg(feature = "proc-macro")]
 use proc_macro;
 use proc_macro2::{TokenStream, TokenTree};
 
@@ -108,6 +109,7 @@ impl From<Tokens> for TokenStream {
     }
 }
 
+#[cfg(feature = "proc-macro")]
 impl From<Tokens> for proc_macro::TokenStream {
     fn from(tokens: Tokens) -> proc_macro::TokenStream {
         TokenStream::from(tokens).into()


### PR DESCRIPTION
@dtolnay Would you consider merging something like this?

Root problem is rust-lang/rust#47931 - my patch at rust-lang/rust#48217 would have solved it but is stalled. So as a workaround to get unblocked we extracted libproc_macro and published it as a standalone `rustc-ap-proc_macro` crate on crates.io, similar to how other libraries inside rustc are published as standalone crates (although I did it manually instead of scripting it, see alexcrichton/rustc-auto-publish#1). We then also forked `proc-macro2`, `quote`, and `syn` to standalone variants (now on crates.io as `standalone-proc-macro2`, `standalone-quote`, and `standalone-syn`) and updated `cbindgen` to use those. This solved our immediate problem, but is a pretty bad solution overall.

To make it a little better, it should be possible to just have a feature flag on `proc-macro2`, `quote`, and `syn` that does the same job, instead of having to fork the entire crate. This PR shows what the feature would look like for `quote` - if this looks acceptable to you I can do one for `syn` as well. Thoughts/comments?

Note that I haven't verified this actually does what I want it to (in terms of making `cbindgen` use this feature) but if you have no objections to the general idea then I can do that prior to merging this.