### PR TITLE
Handle negative literals a bit better

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -133,7 +133,7 @@ fn test_integer() {
         #ii8 #ii16 #ii32 #ii64 #iisize
         #uu8 #uu16 #uu32 #uu64 #uusize
     };
-    let expected = "-1i8 -1i16 -1i32 -1i64 -1isize 1u8 1u16 1u32 1u64 1usize";
+    let expected = "- 1i8 - 1i16 - 1i32 - 1i64 - 1isize 1u8 1u16 1u32 1u64 1usize";
     assert_eq!(expected, tokens.to_string());
 }
 
@@ -289,4 +289,18 @@ fn test_append_tokens() {
     let b = quote!(b);
     a.append_all(b);
     assert_eq!("a b", a.to_string());
+}
+
+#[test]
+fn negative_integers() {
+    let a = -1i32;
+    let a = quote!(#a);
+    assert_eq!("- 1i32", a.to_string());
+}
+
+#[test]
+fn negative_min() {
+    let a = -128i8;
+    let a = quote!(#a);
+    assert_eq!("( 18446744073709551488u64 as i8 )", a.to_string());
 }


### PR DESCRIPTION
Looks like upstream in rust-lang/rust negative integers are represented as two
tokens instead of one token (and it looks like proc_macro may erroneously (?)
accept negative integers as literals, see rust-lang/rust#48889). As a result
tweak the `ToTokens` impls for signed integers to maybe put a `-` token out in
front. Similar treatment is applied to f32/f64 as well.

Special treatment is required, however, for the `iNN::min_value()` constants.
The actual integral portion isn't actually representable as a positive integer
literal (as it'd overflow back to negative) so to handle this case everything is
just represented as a u64 literal cast to the right type.