### PR TITLE
Add assert_tokens! macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,20 @@ macro_rules! quote_spanned {
     };
 }
 
+/// Asserts that `val` has the given token representation, for testing.
+/// 
+/// Equivalent to `assert!($fmt, $val.into_tokens(), quote! { $($tt)* })`; the
+/// format string is optional.
+#[macro_export]
+macro_rules! assert_tokens {
+    ($fmt:expr, $val:expr; $($tt:tt)*) => (
+        assert_eq!!($fmt, $val.into_tokens(), quote! { $($tt)* })
+    );
+    ($val:expr; $($tt:tt)*) => (
+        assert_eq!!($val.into_tokens(), quote! { $($tt)* })
+    )
+}
+
 // Extract the names of all #metavariables and pass them to the $finish macro.
 //
 // in:   pounded_var_names!(then () a #b c #( #d )* #e)


### PR DESCRIPTION
I found myself writing `assert_eq!(item.into_tokens(), quote! { ... })` often enough in tests that I figured that something like this might be useful. It shouldn't be much of a maintenance burden, although I'm open to suggestions on how the documentation should be worded.

I also noticed that the existing tests use `to_string` and I'm not 100% sure what the difference here would be. I'd be more than happy to move over the tests for syn and quote to this as a form of testing it.