### PR TITLE
Ignore proc-macro feature on wasm-target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 // Quote types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/quote/0.6.5")]
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 extern crate proc_macro;
 extern crate proc_macro2;
 


### PR DESCRIPTION
Same as [this](https://github.com/dtolnay/syn/pull/469): Ignore `proc-macro` if it's not available anyway, cause it might have been leaked from an actual proc-macro that runs on the host.

I'd be nice to bump this into a 0.6 release so everyone can just `cargo update`.