### PR TITLE
Optimize for rustc 1.20+ which can match ident faster

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,13 @@ fn main() {
         None => return,
     };
 
+    // Rust 1.20 fixed a macro matching limitation that we can use for a
+    // performance win when matching $:ident.
+    // https://github.com/rust-lang/rust/pull/42913
+    if minor >= 20 {
+        println!("cargo:rustc-cfg=quote_can_special_case_ident");
+    }
+
     // 128-bit integers stabilized in Rust 1.26:
     // https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
     if minor >= 26 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -844,8 +844,30 @@ macro_rules! quote_each_token {
     };
 
     ($tokens:ident $span:ident $first:tt $($rest:tt)*) => {
-        $crate::__rt::parse(&mut $tokens, $span, quote_stringify!($first));
+        quote_ident_or_tt!($tokens $span $first);
         quote_each_token!($tokens $span $($rest)*);
+    };
+}
+
+#[cfg(quote_can_special_case_ident)]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! quote_ident_or_tt {
+    ($tokens:ident $span:ident $first:ident) => {
+        $crate::__rt::push_ident(&mut $tokens, $span, quote_stringify!($first));
+    };
+
+    ($tokens:ident $span:ident $first:tt) => {
+        $crate::__rt::push_tt(&mut $tokens, $span, quote_stringify!($first));
+    };
+}
+
+#[cfg(not(quote_can_special_case_ident))]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! quote_ident_or_tt {
+    ($tokens:ident $span:ident $first:tt) => {
+        $crate::__rt::slow::parse(&mut $tokens, $span, quote_stringify!($first));
     };
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,43 +1,59 @@
 use ext::TokenStreamExt;
 pub use proc_macro2::*;
 
-fn is_ident_start(c: u8) -> bool {
-    (b'a' <= c && c <= b'z') || (b'A' <= c && c <= b'Z') || c == b'_'
-}
+#[cfg(not(quote_can_special_case_ident))]
+pub mod slow {
+    use proc_macro2::{Span, TokenStream};
 
-fn is_ident_continue(c: u8) -> bool {
-    (b'a' <= c && c <= b'z') || (b'A' <= c && c <= b'Z') || c == b'_' || (b'0' <= c && c <= b'9')
-}
-
-fn is_ident(token: &str) -> bool {
-    if token.bytes().all(|digit| digit >= b'0' && digit <= b'9') {
-        return false;
+    fn is_ident_start(c: u8) -> bool {
+        (b'a' <= c && c <= b'z') || (b'A' <= c && c <= b'Z') || c == b'_'
     }
 
-    let mut bytes = token.bytes();
-    let first = bytes.next().unwrap();
-    if !is_ident_start(first) {
-        return false;
+    fn is_ident_continue(c: u8) -> bool {
+        (b'a' <= c && c <= b'z')
+            || (b'A' <= c && c <= b'Z')
+            || c == b'_'
+            || (b'0' <= c && c <= b'9')
     }
-    for ch in bytes {
-        if !is_ident_continue(ch) {
+
+    fn is_ident(token: &str) -> bool {
+        if token.bytes().all(|digit| digit >= b'0' && digit <= b'9') {
             return false;
         }
+
+        let mut bytes = token.bytes();
+        let first = bytes.next().unwrap();
+        if !is_ident_start(first) {
+            return false;
+        }
+        for ch in bytes {
+            if !is_ident_continue(ch) {
+                return false;
+            }
+        }
+        true
     }
-    true
+
+    pub fn parse(tokens: &mut TokenStream, span: Span, s: &str) {
+        if is_ident(s) {
+            // Fast path, since idents are the most common token.
+            super::push_ident(tokens, span, s);
+        } else {
+            super::push_tt(tokens, span, s);
+        }
+    }
 }
 
-pub fn parse(tokens: &mut TokenStream, span: Span, s: &str) {
-    if is_ident(s) {
-        // Fast path, since idents are the most common token.
-        tokens.append(Ident::new(s, span));
-    } else {
-        let s: TokenStream = s.parse().expect("invalid token stream");
-        tokens.extend(s.into_iter().map(|mut t| {
-            t.set_span(span);
-            t
-        }));
-    }
+pub fn push_ident(tokens: &mut TokenStream, span: Span, s: &str) {
+    tokens.append(Ident::new(s, span));
+}
+
+pub fn push_tt(tokens: &mut TokenStream, span: Span, s: &str) {
+    let s: TokenStream = s.parse().expect("invalid token stream");
+    tokens.extend(s.into_iter().map(|mut t| {
+        t.set_span(span);
+        t
+    }));
 }
 
 macro_rules! push_punct {


### PR DESCRIPTION
This performs about 10% better on my machine: the included benchmark is down from 160 microseconds to 144 microseconds.

Mentioning @nnethercote regarding https://github.com/alexcrichton/proc-macro2/pull/94#issuecomment-452512128 -- would you like to try this commit in the rustc-perf benchmark before merging?