### PR TITLE
Advertise the existence of proc-quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ macro.
 
 ### Limitations
 
+If any of the following limitations is hindering you too much, you might want to
+consider using the [proc-quote] crate instead.
+
 - A non-repeating variable may not be interpolated inside of a repeating block
   ([#7]).
 - The same variable may not be interpolated more than once inside of a repeating
@@ -216,6 +219,7 @@ macro.
 
 [#7]: https://github.com/dtolnay/quote/issues/7
 [#8]: https://github.com/dtolnay/quote/issues/8
+[proc-quote]: https://github.com/Goncalerta/proc-quote
 
 ### Recursion limit
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,11 @@ pub mod __rt {
 ///   `#(#ident #vec)*` is not allowed. Work around this by using
 ///   `std::iter::repeat(ident)` to produce an iterable that can be used from
 ///   within the repetition.
+/// 
+/// Alternatively, you might want to consider using [proc-quote] which overcomes
+/// those limitations.
+/// 
+/// [proc-quote]: https://docs.rs/proc-quote/0.1.0/proc_quote/macro.quote.html
 ///
 /// # Hygiene
 ///


### PR DESCRIPTION
Users of this crate might not be aware of the existence of proc-quote, even if they often need to workaround the limitation of multiple interpolation of the same iterator.

Adding a reference to proc-quote so more users notice this possibility.