### PR TITLE
Support duplicate interpolations within repetitions (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,6 @@ macro.
 
 [`quote_spanned!`]: https://docs.rs/quote/0.6/quote/macro.quote_spanned.html
 
-### Limitations
-
-- A non-repeating variable may not be interpolated inside of a repeating block
-  ([#7]).
-
-[#7]: https://github.com/dtolnay/quote/issues/7
-
 ### Recursion limit
 
 The `quote!` macro relies on deep recursion so some large invocations may fail

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ a pre-existing iterator.
 - `#(#var),*` — the character before the asterisk is used as a separator
 - `#( struct #var; )*` — the repetition can contain other things
 - `#( #k => println!("{}", #v), )*` — even multiple interpolations
+- `#(#var #var)*` - or duplicate interpolations
 
 Note that there is a difference between `#(#var ,)*` and `#(#var),*`—the latter
 does not produce a trailing comma. This matches the behavior of delimiters in
@@ -211,11 +212,8 @@ macro.
 
 - A non-repeating variable may not be interpolated inside of a repeating block
   ([#7]).
-- The same variable may not be interpolated more than once inside of a repeating
-  block ([#8]).
 
 [#7]: https://github.com/dtolnay/quote/issues/7
-[#8]: https://github.com/dtolnay/quote/issues/8
 
 ### Recursion limit
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -234,8 +234,34 @@ fn test_nested_fancy_repetition() {
 
 #[test]
 fn test_empty_repetition() {
+    #[allow(unreachable_code)]
     let tokens = quote!(#(a b)* #(c d),*);
     assert_eq!("", tokens.to_string());
+}
+
+#[test]
+fn test_duplicate_name_repetition() {
+    let foo = &["a", "b"];
+
+    let tokens = quote! {
+        #(#foo: #foo),*
+        #(#foo: #foo),*
+    };
+
+    let expected = r#""a" : "a" , "b" : "b" "a" : "a" , "b" : "b""#;
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_duplicate_name_repetition_no_copy() {
+    let foo = vec!["a".to_owned(), "b".to_owned()];
+
+    let tokens = quote! {
+        #(#foo: #foo),*
+    };
+
+    let expected = r#""a" : "a" , "b" : "b""#;
+    assert_eq!(expected, tokens.to_string());
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -275,6 +275,43 @@ fn test_variable_name_conflict() {
 }
 
 #[test]
+fn test_nonrep_in_repetition() {
+    let rep = vec!["a", "b"];
+    let nonrep = "c";
+
+    let tokens = quote! {
+        #(#rep #rep : #nonrep #nonrep),*
+    };
+
+    let expected = r#""a" "a" : "c" "c" , "b" "b" : "c" "c""#;
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_nonrep_only_repetition() {
+    let nonrep = "a";
+
+    // Without the `has_iter` parameter to `__quote_into_iter()`, this would
+    // loop infinitely.
+    let tokens = quote!( #(#nonrep)* );
+    let expected = "";
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_nonrep_only_repetition_dup() {
+    let nonrep = "a";
+
+    // If the `__quote_into_iter()` method for `nonrep` produced a real
+    // iterator, this would loop infinitely.
+    let tokens = quote!( #(#nonrep #nonrep)* );
+    let expected = "";
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
 fn test_empty_quote() {
     let tokens = quote!();
     assert_eq!("", tokens.to_string());


### PR DESCRIPTION
This eliminates the restrictions around duplicate interpolations by taking advantage of shadowing of let bindings within generated loops and rust deref coersion within a desugared loop.

Duplicate calls to `IntoIter::into_iter` are handled, as the duplicates will be called on the already-bound iterator objects, meaning that the call is a no-op.

Duplicate calls to `next()` are also handled by wrapping each interpolation within the loop into a `RepInterp<T>` wrapper. This wrapper provides a dummy inherent `next` method which ensures that `next` is only called once per iterator per loop.

As a side-benefit, this has the effect of producing `unused_code` warnings when no interpolations occur within a repetition block, as rustc can see an unconditional break statement before code to generate the repetition body.

This has been tested working in rustc 1.15.1, although extraneous `unused_mut` warnings are emitted due to `#[allow(unused_mut)]` being ignored on statements in that release.

The generated code looks similar to the following:

```rust
// quote!(#(#a #b #a),*);

// ...
{
    let mut _i = 0; // Only used if sep is present.

    // Get and bind iterators to use for the capture repetition.
    #[allow(unused_mut)] let mut a = a.into_iter();
    #[allow(unused_mut)] let mut b = b.into_iter();

    // Duplicate names are a no-op, as IntoIter::into_iter is idempotent.
    #[allow(unused_mut)] let mut a = a.into_iter();

    loop {
        // Calls `Iterator::next` and wraps the result in `RepInterp` if `Some`.
        let a = match a.next() {
            Some(_x) => $crate::__rt::RepInterp(_x),
            None => break,
        };
        let b = match b.next() {
            Some(_x) => $crate::__rt::RepInterp(_x),
            None => break,
        };

        // No-op `next()` call for duplicate names, as `RepInterp` defines an
        // inherent `next(self) -> Option<T>` method.
        let a = match a.next() {
            Some(_x) => $crate::__rt::RepInterp(_x),
            None => break,
        };

        if _i > 0 {
            quote_each_token!(tokens span ,);
        }
        _i += 1;

        quote_each_token!(tokens span #a #b #a);
    }
}
// ...
```