### PR TITLE
Add a format_ident! helper macro (#110)

### DIFF
--- a/src/ident_fragment.rs
+++ b/src/ident_fragment.rs
@@ -1,0 +1,93 @@
+use proc_macro2::{Ident, Span};
+use std::fmt;
+
+/// Specialized formatting trait used by [`format_ident!`].
+///
+/// [`Ident`] arguments formatted using this trait will have their `r#` prefix
+/// stripped, if present.
+///
+/// See [`format_ident!`] for more information.
+pub trait IdentFragment {
+    /// Format this value as an identifier fragment.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result;
+
+    /// Span associated with this [`IdentFragment`].
+    ///
+    /// If non-`None`, may be inherited by formatted identifiers.
+    #[inline]
+    fn span(&self) -> Option<Span> {
+        None
+    }
+}
+
+impl<'a, T: IdentFragment + ?Sized> IdentFragment for &'a T {
+    #[inline]
+    fn span(&self) -> Option<Span> {
+        <T as IdentFragment>::span(*self)
+    }
+
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        IdentFragment::fmt(*self, f)
+    }
+}
+
+impl<'a, T: IdentFragment + ?Sized> IdentFragment for &'a mut T {
+    #[inline]
+    fn span(&self) -> Option<Span> {
+        <T as IdentFragment>::span(*self)
+    }
+
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        IdentFragment::fmt(*self, f)
+    }
+}
+
+impl IdentFragment for Ident {
+    #[inline]
+    fn span(&self) -> Option<Span> {
+        Some(self.span())
+    }
+
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let id = self.to_string();
+        if id.starts_with("r#") {
+            fmt::Display::fmt(&id[2..], f)
+        } else {
+            fmt::Display::fmt(&id[..], f)
+        }
+    }
+}
+
+// Limited set of types which this is implemented for, as we want to avoid types
+// which will often include non-identifier characters in their `Display` impl.
+macro_rules! ident_fragment_display {
+    ($($T:ty),*) => {
+        $(
+            impl IdentFragment for $T {
+                #[inline]
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fmt::Display::fmt(self, f)
+                }
+            }
+        )*
+    }
+}
+
+ident_fragment_display!(bool, str, String);
+ident_fragment_display!(u8, u16, u32, u64, usize);
+
+#[cfg(integer128)]
+ident_fragment_display!(u128);
+
+// XXX: Should we implement `IdentFragment` for signed integers? It's a touch
+// inconvenient that the default inferred type for integer literals isn't a
+// valid `IdentFragment`.
+
+// XXX: Should `IdentFragment` be implemented for types like `NonZeroUsize`
+// ident_fragment_display!(
+//     num::NonZeroU8, num::NonZeroU16, num::NonZeroU32,
+//     num::NonZeroU64, num::NonZeroU128, num::NonZeroUsize
+// );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,9 @@ pub use ext::TokenStreamExt;
 mod to_tokens;
 pub use to_tokens::ToTokens;
 
+mod ident_fragment;
+pub use ident_fragment::IdentFragment;
+
 // Not public API.
 #[doc(hidden)]
 #[path = "runtime.rs"]
@@ -871,5 +874,147 @@ macro_rules! quote_each_token {
 macro_rules! quote_stringify {
     ($tt:tt) => {
         stringify!($tt)
+    };
+}
+
+/// Formatting macro for constructing [`Ident`]s.
+///
+/// [`Ident`]: `proc_macro2::Ident`
+///
+/// # Syntax
+///
+/// Syntax is copied from the [`format!`] macro, supporting both positional and
+/// named arguments.
+///
+/// Only a limited set of formatting traits are supported. The current mapping
+/// of format types to traits is:
+///
+/// * *nothing* ⇒ [`IdentFragment`]
+/// * `o` ⇒ [`Octal`](`std::fmt::Octal`)
+/// * `x` ⇒ [`LowerHex`](`std::fmt::LowerHex`)
+/// * `X` ⇒ [`UpperHex`](`std::fmt::UpperHex`)
+/// * `b` ⇒ [`Binary`](`std::fmt::Binary`)
+///
+/// See [`std::fmt`] for more information.
+///
+/// # IdentFragment
+///
+/// Unlike [`format!`], this macro uses the [`IdentFragment`] formatting trait
+/// by default. This trait is like `Display`, with a few differences:
+///
+/// * `IdentFragment` is only implemented for a limited set of types, such as
+///    unsigned integers and strings.
+/// * [`Ident`] arguments will have their `r#` prefixes stripped, if present.
+///
+/// # Hygiene
+///
+/// The [`Span`] of the first [`Ident`] argument is used as the span of the
+/// final identifier, falling back to [`Span::call_site`] when no identifiers
+/// are provided.
+///
+/// ```edition2018
+/// # use quote::format_ident;
+/// # let ident = format_ident!("Ident");
+/// // If `ident` is an Ident, the span of `my_ident` will be inherited from it.
+/// let my_ident = format_ident!("My{}{}", ident, "IsCool");
+/// assert_eq!(my_ident, "MyIdentIsCool");
+/// ```
+///
+/// Alternatively, the span can be overridden by passing the `span` named
+/// argument.
+///
+/// ```edition2018
+/// # use quote::format_ident;
+/// # const IGNORE_TOKENS: &'static str = stringify! {
+/// let my_span = /* ... */;
+/// # };
+/// # let my_span = proc_macro2::Span::call_site();
+/// format_ident!("MyIdent", span = my_span);
+/// ```
+///
+/// [`Span`]: `proc_macro2::Span`
+/// [`Span::call_site`]: `proc_macro2::Span::call_site`
+///
+/// # Panics
+///
+/// This method will panic if the formatted string is not a valid identifier, or
+/// a formatting trait implementation returned an error.
+///
+/// # Examples
+///
+/// Composing raw and non-raw identifiers:
+/// ```edition2018
+/// # use quote::format_ident;
+/// let my_ident = format_ident!("My{}", "Ident");
+/// assert_eq!(my_ident, "MyIdent");
+///
+/// let raw = format_ident!("r#Raw");
+/// assert_eq!(raw, "r#Raw");
+///
+/// let my_ident_raw = format_ident!("{}Is{}", my_ident, raw);
+/// assert_eq!(my_ident_raw, "MyIdentIsRaw");
+/// ```
+///
+/// Integer formatting options:
+/// ```edition2018
+/// # use quote::format_ident;
+/// let num: u32 = 10;
+///
+/// let decimal = format_ident!("Id_{}", num);
+/// assert_eq!(decimal, "Id_10");
+///
+/// let octal = format_ident!("Id_{:o}", num);
+/// assert_eq!(octal, "Id_12");
+///
+/// let binary = format_ident!("Id_{:b}", num);
+/// assert_eq!(binary, "Id_1010");
+///
+/// let lower_hex = format_ident!("Id_{:x}", num);
+/// assert_eq!(lower_hex, "Id_a");
+///
+/// let upper_hex = format_ident!("Id_{:X}", num);
+/// assert_eq!(upper_hex, "Id_A");
+/// ```
+#[macro_export]
+macro_rules! format_ident {
+    // Final State
+    (@@ [$span:expr, $($o:tt)*] $(,)*) => {
+        $crate::__rt::mk_ident(&format!($($o)*), $span)
+    };
+
+    // Span Argument
+    (@@ [$_sp:expr, $($o:tt)*] span = $span:expr, $($t:tt)*) => {
+        format_ident!(@@ [
+            ::std::option::Option::Some::<$crate::__rt::Span>($span),
+            $($o)*
+        ] $($t)*)
+    };
+
+    // Named Arguments
+    (@@ [$span:expr, $($o:tt)*] $i:ident = $e:expr, $($t:tt)*) => {
+        match $crate::__rt::IdentFragmentAdapter(&$e) {
+            arg => format_ident!(@@ [$span.or(arg.span()), $($o)*, $i = arg] $($t)*),
+        }
+    };
+
+    // Positional Arguments
+    (@@ [$span:expr, $($o:tt)*] $e:expr, $($t:tt)*) => {
+        match $crate::__rt::IdentFragmentAdapter(&$e) {
+            arg => format_ident!(@@ [$span.or(arg.span()), $($o)*, arg] $($t)*),
+        }
+    };
+
+    // Argument Options
+    ($f:expr) => {
+        format_ident!(@@ [
+            ::std::option::Option::None,
+            $f
+        ])
+    };
+    ($f:expr, $($t:tt)*) => {
+        format_ident!(@@ [
+            ::std::option::Option::None,
+            $f
+        ] $($t)*,)
     };
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -338,7 +338,7 @@ fn test_cow() {
 #[test]
 fn test_closure() {
     fn field_i(i: usize) -> Ident {
-        Ident::new(&format!("__field{}", i), Span::call_site())
+        format_ident!("__field{}", i)
     }
 
     let fields = (0usize..3)
@@ -355,4 +355,34 @@ fn test_append_tokens() {
     let b = quote!(b);
     a.append_all(b);
     assert_eq!("a b", a.to_string());
+}
+
+#[test]
+fn test_format_ident() {
+    let id0 = format_ident!("Aa");
+    let id1 = format_ident!("Hello{x}", x = id0);
+    let id2 = format_ident!("Hello{x}", x = 5usize);
+    let id3 = format_ident!("Hello{}_{x}", id0, x = 10usize);
+    let id4 = format_ident!("Aa", span = Span::call_site());
+
+    assert_eq!(id0, "Aa");
+    assert_eq!(id1, "HelloAa");
+    assert_eq!(id2, "Hello5");
+    assert_eq!(id3, "HelloAa_10");
+    assert_eq!(id4, "Aa");
+
+    // XXX: No way to test spans are set correctly?
+}
+
+#[test]
+fn test_format_ident_strip_raw() {
+    let id = format_ident!("r#struct");
+    let my_id = format_ident!("MyId{}", id);
+    let raw_my_id = format_ident!("r#MyId{}", id);
+
+    assert_eq!(id, "r#struct");
+    assert_eq!(my_id, "MyIdstruct");
+    assert_eq!(raw_my_id, "r#MyIdstruct");
+
+    // XXX: No way to test spans are set correctly?
 }


### PR DESCRIPTION
This is similar to the initial proposal in #110, with a few changes.

1. If an `Ident` was used to provide a fragment within the final formatted
   string, the default behaviour has been changed to inheret the `Span` from it.
   The idea here is to produce good spans for formatted identifiers by default,
   attributing them to the source of their name.

   The `span` named argument can still be used to override this decision.

2. `Ident::new(...)` doesn't support creating raw identifiers, and
   `Ident::new_raw` is still unstable, so the initial behaviour of directly
   passing the result of `format!` into `Ident::new(...)` turned out not to
   work.

   Instead, a helper method was added, `__rt::mk_ident`, which will handle
   creating raw identifiers using the roundabout "parse as TokenStream and
   unwrap" approach.

   I thought it was important to support raw identifiers in `format_ident!` as
   people may want to be able to write `format_ident!("r#{}_{}", a, b)` or
   similar to ensure that their identifiers are never confused for keywords.

3. It turns out it's basically impossible to compare spans right now, and
   there's no stable way to produce a span other than `Span::call_site()`, so no
   tests check that the spans are passed around correctly.