### PR TITLE
Bump minimum rust version to 1.31.0 for quote-next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: rust
 
 rust:
   - stable
-  - 1.15.1
+  - 1.31.0
   - beta
 
 script:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,9 +177,11 @@ pub mod __rt;
 /// ```edition2018
 /// # #[cfg(any())]
 /// extern crate proc_macro;
-/// # use proc_macro2 as proc_macro;
+/// # extern crate proc_macro2;
 ///
+/// # #[cfg(any())]
 /// use proc_macro::TokenStream;
+/// # use proc_macro2::TokenStream;
 /// use quote::quote;
 ///
 /// # const IGNORE_TOKENS: &'static str = stringify! {


### PR DESCRIPTION
This just bumps up the version used for testing on travis, and fixes a doctest failure.