### PR TITLE
Reject repetitions not containing any iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,9 +564,9 @@ macro_rules! quote_each_token {
     ($tokens:ident $span:ident # ( $($inner:tt)* ) * $($rest:tt)*) => {
         {
             use $crate::__rt::ext::*;
-            let has_iter = $crate::__rt::logic::False;
+            let has_iter = $crate::__rt::ThereIsNoIteratorInRepetition;
             pounded_var_names!(quote_bind_into_iter!(has_iter {}) () $($inner)*);
-            $crate::__rt::require_has_iter(has_iter);
+            let _: $crate::__rt::HasIterator = has_iter;
             loop {
                 pounded_var_names!(quote_bind_next_or_break!({}) () $($inner)*);
                 quote_each_token!($tokens $span $($inner)*);
@@ -579,9 +579,9 @@ macro_rules! quote_each_token {
         {
             use $crate::__rt::ext::*;
             let mut _i = 0usize;
-            let has_iter = $crate::__rt::logic::False;
+            let has_iter = $crate::__rt::ThereIsNoIteratorInRepetition;
             pounded_var_names!(quote_bind_into_iter!(has_iter {}) () $($inner)*);
-            $crate::__rt::require_has_iter(has_iter);
+            let _: $crate::__rt::HasIterator = has_iter;
             loop {
                 pounded_var_names!(quote_bind_next_or_break!({}) () $($inner)*);
                 if _i > 0 {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,45 +1,38 @@
 use ext::TokenStreamExt;
 pub use proc_macro2::*;
+use std::ops::BitOr;
 use ToTokens;
 
-pub mod logic {
-    use std::ops::BitOr;
+pub struct HasIterator; // True
+pub struct ThereIsNoIteratorInRepetition; // False
 
-    pub struct True;
-    pub struct False;
-
-    impl BitOr<False> for False {
-        type Output = False;
-        fn bitor(self, _rhs: False) -> False {
-            False
-        }
-    }
-
-    impl BitOr<False> for True {
-        type Output = True;
-        fn bitor(self, _rhs: False) -> True {
-            True
-        }
-    }
-
-    impl BitOr<True> for False {
-        type Output = True;
-        fn bitor(self, _rhs: True) -> True {
-            True
-        }
-    }
-
-    impl BitOr<True> for True {
-        type Output = True;
-        fn bitor(self, _rhs: True) -> True {
-            True
-        }
+impl BitOr<ThereIsNoIteratorInRepetition> for ThereIsNoIteratorInRepetition {
+    type Output = ThereIsNoIteratorInRepetition;
+    fn bitor(self, _rhs: ThereIsNoIteratorInRepetition) -> ThereIsNoIteratorInRepetition {
+        ThereIsNoIteratorInRepetition
     }
 }
 
-pub trait HasIter {}
-impl HasIter for logic::True {}
-pub fn require_has_iter<T: HasIter>(_: T) {}
+impl BitOr<ThereIsNoIteratorInRepetition> for HasIterator {
+    type Output = HasIterator;
+    fn bitor(self, _rhs: ThereIsNoIteratorInRepetition) -> HasIterator {
+        HasIterator
+    }
+}
+
+impl BitOr<HasIterator> for ThereIsNoIteratorInRepetition {
+    type Output = HasIterator;
+    fn bitor(self, _rhs: HasIterator) -> HasIterator {
+        HasIterator
+    }
+}
+
+impl BitOr<HasIterator> for HasIterator {
+    type Output = HasIterator;
+    fn bitor(self, _rhs: HasIterator) -> HasIterator {
+        HasIterator
+    }
+}
 
 /// Extension traits used by the implementation of `quote!`. These are defined
 /// in separate traits, rather than as a single trait due to ambiguity issues.
@@ -48,10 +41,9 @@ pub fn require_has_iter<T: HasIter>(_: T) {}
 /// whichever impl happens to be applicable. Calling that method repeatedly on
 /// the returned value should be idempotent.
 pub mod ext {
+    use super::{HasIterator as HasIter, ThereIsNoIteratorInRepetition as DoesNotHaveIter};
     use std::slice;
     use ToTokens;
-
-    use super::logic::{False as DoesNotHaveIter, True as HasIter};
 
     /// Extension trait providing the `__quote_into_iter` method on iterators.
     pub trait RepIteratorExt: Iterator + Sized {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -233,13 +233,6 @@ fn test_nested_fancy_repetition() {
 }
 
 #[test]
-fn test_empty_repetition() {
-    #[allow(unreachable_code)]
-    let tokens = quote!(#(a b)* #(c d),*);
-    assert_eq!("", tokens.to_string());
-}
-
-#[test]
 fn test_duplicate_name_repetition() {
     let foo = &["a", "b"];
 
@@ -284,30 +277,6 @@ fn test_nonrep_in_repetition() {
     };
 
     let expected = r#""a" "a" : "c" "c" , "b" "b" : "c" "c""#;
-    assert_eq!(expected, tokens.to_string());
-}
-
-#[test]
-fn test_nonrep_only_repetition() {
-    let nonrep = "a";
-
-    // Without the `has_iter` parameter to `__quote_into_iter()`, this would
-    // loop infinitely.
-    let tokens = quote!( #(#nonrep)* );
-    let expected = "";
-
-    assert_eq!(expected, tokens.to_string());
-}
-
-#[test]
-fn test_nonrep_only_repetition_dup() {
-    let nonrep = "a";
-
-    // If the `__quote_into_iter()` method for `nonrep` produced a real
-    // iterator, this would loop infinitely.
-    let tokens = quote!( #(#nonrep #nonrep)* );
-    let expected = "";
-
     assert_eq!(expected, tokens.to_string());
 }
 

--- a/tests/ui/does-not-have-iter-interpolated-dup.rs
+++ b/tests/ui/does-not-have-iter-interpolated-dup.rs
@@ -1,0 +1,9 @@
+use quote::quote;
+
+fn main() {
+    let nonrep = "";
+
+    // Without some protection against repetitions with no iterator somewhere
+    // inside, this would loop infinitely.
+    quote!(#(#nonrep #nonrep)*);
+}

--- a/tests/ui/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/does-not-have-iter-interpolated-dup.stderr
@@ -1,10 +1,11 @@
-error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+error[E0308]: mismatched types
  --> $DIR/does-not-have-iter-interpolated-dup.rs:8:5
   |
 8 |     quote!(#(#nonrep #nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `quote::__rt::HasIterator`, found struct `quote::__rt::ThereIsNoIteratorInRepetition`
   |
-  = note: required by `quote::__rt::require_has_iter`
+  = note: expected type `quote::__rt::HasIterator`
+             found type `quote::__rt::ThereIsNoIteratorInRepetition`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/does-not-have-iter-interpolated-dup.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+ --> $DIR/does-not-have-iter-interpolated-dup.rs:8:5
+  |
+8 |     quote!(#(#nonrep #nonrep)*);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |
+  = note: required by `quote::__rt::require_has_iter`
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/does-not-have-iter-interpolated.rs
+++ b/tests/ui/does-not-have-iter-interpolated.rs
@@ -1,0 +1,9 @@
+use quote::quote;
+
+fn main() {
+    let nonrep = "";
+
+    // Without some protection against repetitions with no iterator somewhere
+    // inside, this would loop infinitely.
+    quote!(#(#nonrep)*);
+}

--- a/tests/ui/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/does-not-have-iter-interpolated.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+ --> $DIR/does-not-have-iter-interpolated.rs:8:5
+  |
+8 |     quote!(#(#nonrep)*);
+  |     ^^^^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |
+  = note: required by `quote::__rt::require_has_iter`
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/does-not-have-iter-interpolated.stderr
@@ -1,10 +1,11 @@
-error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+error[E0308]: mismatched types
  --> $DIR/does-not-have-iter-interpolated.rs:8:5
   |
 8 |     quote!(#(#nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |     ^^^^^^^^^^^^^^^^^^^^ expected struct `quote::__rt::HasIterator`, found struct `quote::__rt::ThereIsNoIteratorInRepetition`
   |
-  = note: required by `quote::__rt::require_has_iter`
+  = note: expected type `quote::__rt::HasIterator`
+             found type `quote::__rt::ThereIsNoIteratorInRepetition`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/does-not-have-iter-separated.rs
+++ b/tests/ui/does-not-have-iter-separated.rs
@@ -1,0 +1,5 @@
+use quote::quote;
+
+fn main() {
+    quote!(#(a b),*);
+}

--- a/tests/ui/does-not-have-iter-separated.stderr
+++ b/tests/ui/does-not-have-iter-separated.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+ --> $DIR/does-not-have-iter-separated.rs:4:5
+  |
+4 |     quote!(#(a b),*);
+  |     ^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |
+  = note: required by `quote::__rt::require_has_iter`
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/does-not-have-iter-separated.stderr
+++ b/tests/ui/does-not-have-iter-separated.stderr
@@ -1,10 +1,11 @@
-error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+error[E0308]: mismatched types
  --> $DIR/does-not-have-iter-separated.rs:4:5
   |
 4 |     quote!(#(a b),*);
-  |     ^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |     ^^^^^^^^^^^^^^^^^ expected struct `quote::__rt::HasIterator`, found struct `quote::__rt::ThereIsNoIteratorInRepetition`
   |
-  = note: required by `quote::__rt::require_has_iter`
+  = note: expected type `quote::__rt::HasIterator`
+             found type `quote::__rt::ThereIsNoIteratorInRepetition`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/does-not-have-iter.rs
+++ b/tests/ui/does-not-have-iter.rs
@@ -1,0 +1,5 @@
+use quote::quote;
+
+fn main() {
+    quote!(#(a b)*);
+}

--- a/tests/ui/does-not-have-iter.stderr
+++ b/tests/ui/does-not-have-iter.stderr
@@ -1,10 +1,11 @@
-error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+error[E0308]: mismatched types
  --> $DIR/does-not-have-iter.rs:4:5
   |
 4 |     quote!(#(a b)*);
-  |     ^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |     ^^^^^^^^^^^^^^^^ expected struct `quote::__rt::HasIterator`, found struct `quote::__rt::ThereIsNoIteratorInRepetition`
   |
-  = note: required by `quote::__rt::require_has_iter`
+  = note: expected type `quote::__rt::HasIterator`
+             found type `quote::__rt::ThereIsNoIteratorInRepetition`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/does-not-have-iter.stderr
+++ b/tests/ui/does-not-have-iter.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
+ --> $DIR/does-not-have-iter.rs:4:5
+  |
+4 |     quote!(#(a b)*);
+  |     ^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
+  |
+  = note: required by `quote::__rt::require_has_iter`
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
It's possible to do the has_iter stuff at compile time. Is this behavior preferable over silently skipping the repetition?

```console
error[E0277]: the trait bound `quote::__rt::logic::False: quote::__rt::HasIter` is not satisfied
 --> $DIR/does-not-have-iter-interpolated.rs:8:5
  |
8 |     quote!(#(#nonrep)*);
  |     ^^^^^^^^^^^^^^^^^^^^ the trait `quote::__rt::HasIter` is not implemented for `quote::__rt::logic::False`
  |
  = note: required by `quote::__rt::require_has_iter`
  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

There may be ways to make the resulting error clearer...