### PR TITLE
Recognize ident tokens instead of doing is_ident at runtime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -942,6 +942,10 @@ macro_rules! quote_token {
         $crate::__rt::push_sub_eq(&mut $tokens, $span);
     };
 
+    ($tokens:ident $span:ident $ident:ident) => {
+        $crate::__rt::push_ident(&mut $tokens, $span, stringify!($ident));
+    };
+
     ($tokens:ident $span:ident $other:tt) => {
         $crate::__rt::parse(&mut $tokens, $span, stringify!($other));
     };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -208,6 +208,10 @@ pub fn parse(tokens: &mut TokenStream, span: Span, s: &str) {
     }
 }
 
+pub fn push_ident(tokens: &mut TokenStream, span: Span, s: &str) {
+    tokens.append(Ident::new(s, span));
+}
+
 macro_rules! push_punct {
     ($name:ident $char1:tt) => {
         pub fn $name(tokens: &mut TokenStream, span: Span) {


### PR DESCRIPTION
This is a rebase of #91. 

| | before | after | Δ |
|---|---|---|---|
| `cargo bench` | 125μs | 119μs | -5% |
| `cargo build --benches && target/debug/bench-* --bench` | 2100μs | 1860μs | -11% |