### PR TITLE
Avoid panic when using quote! on raw identifiers

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -427,3 +427,9 @@ fn test_star_after_repetition() {
     let expected = "f ( '0' ) ; f ( '1' ) ; * out = None ;";
     assert_eq!(expected, tokens.to_string());
 }
+
+#[test]
+fn test_quote_raw_id() {
+    let id = quote!(r#raw_id);
+    assert_eq!(id.to_string(), "r#raw_id");
+}


### PR DESCRIPTION
The `quote!` optimization added in 8d155b02f4a78123f46a1b126756eb61e7d38536 calls `Ident::new`, which does not handle identifiers containing the `r#` raw prefix, panicing if they are passed in.

As `Ident::new_raw` is not stable, raw identifiers are parsed using the existing `parse` codepath, with only non-raw identifiers being passed to `Ident::new`. This mimics the logic from the `mk_ident` method created for `format_ident!`, with some small optimizations due to relaxed requirements.

The previous `is_ident` optimization within `__rt::parse` has also been removed, as it is now redundant.