### PR TITLE
Adds an unsafe_code linting rule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@
 //! };
 //! ```
 
+#![forbid(unsafe_code)]
+
 // Quote types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/quote/1.0.2")]
 


### PR DESCRIPTION
This marks the use of unsafe code within the library as an error.