### PR TITLE
#![no_std] Compatibility

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,6 +1,6 @@
 use super::ToTokens;
 
-use std::iter;
+use core::iter;
 
 use proc_macro2::{TokenStream, TokenTree};
 

--- a/src/ident_fragment.rs
+++ b/src/ident_fragment.rs
@@ -1,5 +1,7 @@
 use proc_macro2::{Ident, Span};
-use std::fmt;
+use core::fmt;
+
+use alloc::string::ToString;
 
 /// Specialized formatting trait used by `format_ident!`.
 ///
@@ -68,5 +70,5 @@ macro_rules! ident_fragment_display {
     }
 }
 
-ident_fragment_display!(bool, str, String);
+ident_fragment_display!(bool, str, alloc::string::String);
 ident_fragment_display!(u8, u16, u32, u64, u128, usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //!     }
 //! };
 //! ```
+#![no_std]
 
 #![forbid(unsafe_code)]
 
@@ -82,6 +83,9 @@
     feature = "proc-macro"
 ))]
 extern crate proc_macro;
+
+#[macro_use]
+extern crate alloc;
 
 mod ext;
 mod format;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::{IdentFragment, ToTokens, TokenStreamExt};
-use std::fmt;
-use std::ops::BitOr;
+use core::fmt;
+use core::ops::BitOr;
 
 pub use proc_macro2::*;
 
@@ -45,8 +45,8 @@ pub mod ext {
     use super::RepInterp;
     use super::{HasIterator as HasIter, ThereIsNoIteratorInRepetition as DoesNotHaveIter};
     use crate::ToTokens;
-    use std::collections::btree_set::{self, BTreeSet};
-    use std::slice;
+    use alloc::collections::btree_set::{self, BTreeSet};
+    use core::slice;
 
     /// Extension trait providing the `quote_into_iter` method on iterators.
     pub trait RepIteratorExt: Iterator + Sized {
@@ -107,7 +107,7 @@ pub mod ext {
         }
     }
 
-    impl<'q, T: 'q> RepAsIteratorExt<'q> for Vec<T> {
+    impl<'q, T: 'q> RepAsIteratorExt<'q> for alloc::vec::Vec<T> {
         type Iter = slice::Iter<'q, T>;
 
         fn quote_into_iter(&'q self) -> (Self::Iter, HasIter) {

--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -1,8 +1,8 @@
 use super::TokenStreamExt;
 
-use std::borrow::Cow;
-use std::iter;
-use std::rc::Rc;
+use alloc::borrow::Cow;
+use core::iter;
+use alloc::rc::Rc;
 
 use proc_macro2::{Group, Ident, Literal, Punct, Span, TokenStream, TokenTree};
 
@@ -88,13 +88,13 @@ impl<'a, T: ?Sized + ToTokens> ToTokens for &'a mut T {
     }
 }
 
-impl<'a, T: ?Sized + ToOwned + ToTokens> ToTokens for Cow<'a, T> {
+impl<'a, T: ?Sized + alloc::borrow::ToOwned + ToTokens> ToTokens for Cow<'a, T> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         (**self).to_tokens(tokens);
     }
 }
 
-impl<T: ?Sized + ToTokens> ToTokens for Box<T> {
+impl<T: ?Sized + ToTokens> ToTokens for alloc::boxed::Box<T> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         (**self).to_tokens(tokens);
     }
@@ -120,7 +120,7 @@ impl ToTokens for str {
     }
 }
 
-impl ToTokens for String {
+impl ToTokens for alloc::string::String {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.as_str().to_tokens(tokens);
     }


### PR DESCRIPTION
The changes allows the crate to be used with #![no_std]. 

The use case is described here:
https://github.com/rust-fuzz/arbitrary/issues/38