### PR TITLE
Implement IdentFragment for Cow<T>

### DIFF
--- a/src/ident_fragment.rs
+++ b/src/ident_fragment.rs
@@ -54,7 +54,10 @@ impl IdentFragment for Ident {
     }
 }
 
-impl<T: IdentFragment + Clone> IdentFragment for std::borrow::Cow<'_, T> {
+impl<'a, T> IdentFragment for std::borrow::Cow<'a, T>
+where
+    T: 'a + IdentFragment + ToOwned + ?Sized,
+{
     fn span(&self) -> Option<Span> {
         T::span(&self)
     }

--- a/src/ident_fragment.rs
+++ b/src/ident_fragment.rs
@@ -54,6 +54,16 @@ impl IdentFragment for Ident {
     }
 }
 
+impl<T: IdentFragment + Clone> IdentFragment for std::borrow::Cow<'_, T> {
+    fn span(&self) -> Option<Span> {
+        T::span(&self)
+    }
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        T::fmt(&self, f)
+    }
+}
+
 // Limited set of types which this is implemented for, as we want to avoid types
 // which will often include non-identifier characters in their `Display` impl.
 macro_rules! ident_fragment_display {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -341,12 +341,14 @@ fn test_format_ident() {
     let id2 = format_ident!("Hello{x}", x = 5usize);
     let id3 = format_ident!("Hello{}_{x}", id0, x = 10usize);
     let id4 = format_ident!("Aa", span = Span::call_site());
+    let id5 = format_ident!("Hello{}", Cow::Borrowed("World"));
 
     assert_eq!(id0, "Aa");
     assert_eq!(id1, "HelloAa");
     assert_eq!(id2, "Hello5");
     assert_eq!(id3, "HelloAa_10");
     assert_eq!(id4, "Aa");
+    assert_eq!(id5, "HelloWorld");
 }
 
 #[test]


### PR DESCRIPTION
This allows users to use `Cow<T>` with `format_ident!` as long as `T: IdentFragment`. I'm currently working on a library that frequently uses `Cow<str>`, which currently requires me to manually deref the `Cow` when using `format_ident!`, e.g.:

```rust
format_ident!("prefix_{}", &*my_cow);
```

With this change, `Cow` behaves "as expected", i.e. users can now do:

```rust
format_ident!("prefix_{}", my_cow);
```