### PR TITLE
Allow inline expressions within quote!()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,6 +732,11 @@ macro_rules! quote_tokens_with_context_spanned {
 macro_rules! quote_token_with_context {
     ($tokens:ident $b3:tt $b2:tt $b1:tt @ $a1:tt $a2:tt $a3:tt) => {};
 
+    ($tokens:ident $b3:tt $b2:tt $b1:tt (#) { $($inner:tt)* } $a2:tt $a3:tt) => {{
+        $tokens.extend($crate::ToTokens::into_token_stream({ $($inner)* }))
+    }};
+    ($tokens:ident $b3:tt $b2:tt # ({ $($inner:tt)* }) $a1:tt $a2:tt $a3:tt) => {};
+
     ($tokens:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) * $a3:tt) => {{
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
@@ -787,6 +792,11 @@ macro_rules! quote_token_with_context {
 #[doc(hidden)]
 macro_rules! quote_token_with_context_spanned {
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt @ $a1:tt $a2:tt $a3:tt) => {};
+
+    ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) { $($inner:tt)* } $a2:tt $a3:tt) => {{
+        $tokens.extend($crate::ToTokens::into_token_stream({ $($inner)* }))
+    }};
+    ($tokens:ident $span:ident $b3:tt $b2:tt # ({ $($inner:tt)* }) $a1:tt $a2:tt $a3:tt) => {};
 
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) * $a3:tt) => {{
         use $crate::__private::ext::*;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -457,3 +457,40 @@ fn test_quote_raw_id() {
     let id = quote!(r#raw_id);
     assert_eq!(id.to_string(), "r#raw_id");
 }
+
+#[test]
+fn test_inline_expr() {
+    fn make(case: bool) -> TokenStream {
+        let quoted_b = quote!(you made this?);
+        quote!(something_before #{
+            if case {
+                quote!(i made this.)
+            } else {
+                quoted_b
+            }
+        } something_after)
+    }
+
+    assert_eq!(make(true).to_string(), "something_before i made this . something_after");
+    assert_eq!(make(false).to_string(), "something_before you made this ? something_after");
+}
+
+
+#[test]
+fn test_inline_expr_spanned() {
+    fn make(case: bool) -> TokenStream {
+        let quoted_b = quote!(you made this?);
+        let span = Span::call_site();
+        quote_spanned!(span=> something_before #{
+            if case {
+                quote!(i made this.)
+            } else {
+                quoted_b
+            }
+        } something_after)
+    }
+
+    assert_eq!(make(true).to_string(), "something_before i made this . something_after");
+    assert_eq!(make(false).to_string(), "something_before you made this ? something_after");
+}
+


### PR DESCRIPTION
This allows `quote!()` to contain "inline expressions".
These are expressions which are evaluated, not quoted.
This simplifies many situations where a procedural macro
needs to generate complex token streams.

For example, this code:

```
  let foo = if x {
    quote!{ something ... }
  } else {
    quote!{ more stuff ... }
  };

  quote! {
    fn foo() -> i32 { 42 + #foo }
  }
```

can be simplified to this:

```
  quote!{
    fn foo() -> i32 {
      42 + #{
        if x {
          quote!{ something ... }
        } else {
          quote!{ more stuff ... }
        }
      }
    }
  }
```

This eliminates the need to bind temporary token streams to variables,
then to refer to those variables by name. Not only does this eliminate
the need for a temporary name, but it can allow code that builds code
to more closely resemble the structure of the code that is generating.
Localized decisions can stay in their proper scope, rather than needing
to be hoisted above a complex quote!{...} expression.

This does change the interpretation of the sequence of tokens `# { ... }`,
so unfortunately this could be considered a breaking change.
However, that sequence of tokens can never be a valid Rust program,
so is unlikely to be in use. It is also not currently interpreted by the
`quote!` macro.
