### PR TITLE
Delete fixed sized array repetition impls

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -123,25 +123,6 @@ pub mod ext {
         }
     }
 
-    macro_rules! array_rep_slice {
-        ($($l:tt)*) => {
-            $(
-                impl<'q, T: 'q> RepAsIteratorExt<'q> for [T; $l] {
-                    type Iter = slice::Iter<'q, T>;
-
-                    fn quote_into_iter(&'q self) -> (Self::Iter, HasIter) {
-                        (self.iter(), HasIter)
-                    }
-                }
-            )*
-        };
-    }
-
-    array_rep_slice!(
-        0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
-        17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
-    );
-
     impl<'q, T: RepAsIteratorExt<'q>> RepAsIteratorExt<'q> for RepInterp<T> {
         type Iter = T::Iter;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -88,6 +88,15 @@ fn test_array() {
 
     let ref_slice: &[u8] = &[0; 40];
     let _ = quote!(#(#ref_slice #ref_slice)*);
+
+    let array: [X; 2] = [X, X]; // !Copy
+    let _ = quote!(#(#array #array)*);
+
+    let ref_array: &[X; 2] = &[X, X];
+    let _ = quote!(#(#ref_array #ref_array)*);
+
+    let ref_slice: &[X] = &[X, X];
+    let _ = quote!(#(#ref_slice #ref_slice)*);
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -79,6 +79,18 @@ fn test_iter() {
 }
 
 #[test]
+fn test_array() {
+    let array: [u8; 40] = [0; 40];
+    let _ = quote!(#(#array #array)*);
+
+    let ref_array: &[u8; 40] = &[0; 40];
+    let _ = quote!(#(#ref_array #ref_array)*);
+
+    let ref_slice: &[u8] = &[0; 40];
+    let _ = quote!(#(#ref_slice #ref_slice)*);
+}
+
+#[test]
 fn test_advanced() {
     let generics = quote!( <'a, T> );
 


### PR DESCRIPTION
These `[T; 0]`&mdash;`[T; 32]` impls are from a long time ago (#109) and may have been necessary at the time, but I was not able to find code that required them. `[T]` has an impl which all of these fall back to via Deref.

If this removal does turn out to break something please lmk. We can easily revert &ndash; though in that case I would plan to look into defining the impl via a const generic.

```rust
impl<'q, T: 'q, const N: usize> RepAsIteratorExt<'q> for [T; N] {
    type Iter = slice::Iter<'q, T>;

    fn quote_into_iter(&'q self) -> (Self::Iter, HasIter) {
        (self.iter(), HasIter)
    }
}
```