### PR TITLE
adding support for std::lazy::Lazy and std::lazy::SyncLazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ default = ["proc-macro"]
 # Disabling the proc-macro feature removes the dynamic library dependency on
 # libproc_macro in the rustc compiler.
 proc-macro = ["proc-macro2/proc-macro"]
+# Enabling the lazy feature adds support for std::lazy::Lazy and std::lazy::Lazy (nightly only)
+lazy = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@
     clippy::wrong_self_convention,
 )]
 
+#![cfg_attr(feature = "lazy", feature(once_cell))]
+
 #[cfg(all(
     not(all(target_arch = "wasm32", target_os = "unknown")),
     feature = "proc-macro"

--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -114,6 +114,20 @@ impl<T: ToTokens> ToTokens for Option<T> {
     }
 }
 
+#[cfg(feature = "lazy")]
+impl<T: ToTokens, F: Fn() -> T> ToTokens for std::lazy::Lazy<T, F> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        std::lazy::Lazy::force(self).to_tokens(tokens)
+    }
+}
+
+#[cfg(feature = "lazy")]
+impl<T: ToTokens, F: Fn() -> T> ToTokens for std::lazy::SyncLazy<T, F> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        std::lazy::SyncLazy::force(self).to_tokens(tokens)
+    }
+}
+
 impl ToTokens for str {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append(Literal::string(self));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,6 @@
+#![cfg_attr(feature = "lazy", feature(once_cell))]
 #![cfg_attr(feature = "cargo-clippy", allow(blacklisted_name))]
+
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
@@ -353,6 +355,22 @@ fn test_cow() {
 
     let tokens = quote! { #owned #borrowed };
     assert_eq!("owned borrowed", tokens.to_string());
+}
+
+#[test]
+#[cfg(feature = "lazy")]
+fn test_lazy_str() {
+    let l = std::lazy::Lazy::new(|| "str".to_owned());
+    let tokens = quote! { #l };
+    assert_eq!("\"str\"", tokens.to_string());
+}
+
+#[test]
+#[cfg(feature = "lazy")]
+fn test_sync_lazy_str() {
+    static L: std::lazy::SyncLazy<String> = std::lazy::SyncLazy::new(|| "str".to_owned());
+    let tokens = quote! { #L };
+    assert_eq!("\"str\"", tokens.to_string());
 }
 
 #[test]


### PR DESCRIPTION
I just ran into a situation where it would be great to have the option to use [`SyncLazy`](https://doc.rust-lang.org/std/lazy/struct.SyncLazy.html) in [`quote!`](https://docs.rs/quote/1.0.9/quote/macro.quote.html).

minimal example:
```rust
/* --snip -- */
use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
use std::lazy::SyncLazy;
use quote::quote;

static SOME_GENERIC: SyncLazy<Ident> = SyncLazy(|| Ident::new("GENERIC", Span::call_site()));

fn generate() -> TokenStream2 {
    quote! {
         fn generated<#SOME_GENERIC>(arg: #SOME_GENERIC) {
             /* -- snip -- */
         }
     }
}
```

To not break builds using the stable compiler, the new implementations are feature gated.

