### PR TITLE
Include a non-default span in proc macro benchmark

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,9 +1,12 @@
-quote_benchmark::run_quote_benchmark!();
+quote_benchmark::run_quote_benchmark!(_);
 
 mod benchmark {
     macro_rules! benchmark {
-        ($quote:expr) => {
+        (|$ident:ident| $quote:expr) => {
+            use proc_macro2::{Ident, Span};
+
             pub fn quote() -> proc_macro2::TokenStream {
+                let $ident = Ident::new("Response", Span::call_site());
                 $quote
             }
         };


### PR DESCRIPTION
This imitates the performance characteristics of a real proc macro slightly better if we special case token trees that transitively contain only call_site spans.