### PR TITLE
Optimize literal tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1070,6 +1070,10 @@ macro_rules! quote_token {
         $crate::__private::push_lifetime(&mut $tokens, stringify!($lifetime));
     };
 
+    ($tokens:ident $literal:literal) => {
+        $crate::__private::push_literal(&mut $tokens, stringify!($literal));
+    };
+
     ($tokens:ident $other:tt) => {
         $crate::__private::parse(&mut $tokens, stringify!($other));
     };
@@ -1287,6 +1291,10 @@ macro_rules! quote_token_spanned {
 
     ($tokens:ident $span:ident $lifetime:lifetime) => {
         $crate::__private::push_lifetime_spanned(&mut $tokens, $span, stringify!($lifetime));
+    };
+
+    ($tokens:ident $span:ident $literal:literal) => {
+        $crate::__private::push_literal_spanned(&mut $tokens, $span, stringify!($literal));
     };
 
     ($tokens:ident $span:ident $other:tt) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,6 @@
 use crate::{IdentFragment, ToTokens, TokenStreamExt};
 use std::fmt;
+use std::iter;
 use std::ops::BitOr;
 
 pub use proc_macro2::*;
@@ -275,6 +276,17 @@ pub fn push_lifetime_spanned(tokens: &mut TokenStream, span: Span, lifetime: &st
         span,
         state: 0,
     });
+}
+
+pub fn push_literal(tokens: &mut TokenStream, repr: &str) {
+    let literal: Literal = repr.parse().expect("invalid token stream");
+    tokens.extend(iter::once(TokenTree::Literal(literal)));
+}
+
+pub fn push_literal_spanned(tokens: &mut TokenStream, span: Span, repr: &str) {
+    let mut literal: Literal = repr.parse().expect("invalid token stream");
+    literal.set_span(span);
+    tokens.extend(iter::once(TokenTree::Literal(literal)));
 }
 
 macro_rules! push_punct {


### PR DESCRIPTION
This doesn't immediately do much by itself, but what we'll want to do is add some kind of `from_str_unchecked` to proc-macro2's Literal type, which can completely skip the parsing (i.e. validating) in the non-macro codepath.