### PR TITLE
Fix boolean as $literal

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -279,14 +279,24 @@ pub fn push_lifetime_spanned(tokens: &mut TokenStream, span: Span, lifetime: &st
 }
 
 pub fn push_literal(tokens: &mut TokenStream, repr: &str) {
-    let literal: Literal = repr.parse().expect("invalid literal");
-    tokens.extend(iter::once(TokenTree::Literal(literal)));
+    // Macro_rules's $literal matcher also matches `true`, `-true`, `false`,
+    // `-false` which are not considered valid values for a proc_macro::Literal.
+    if repr.ends_with('e') {
+        parse(tokens, repr);
+    } else {
+        let literal: Literal = repr.parse().expect("invalid literal");
+        tokens.extend(iter::once(TokenTree::Literal(literal)));
+    }
 }
 
 pub fn push_literal_spanned(tokens: &mut TokenStream, span: Span, repr: &str) {
-    let mut literal: Literal = repr.parse().expect("invalid literal");
-    literal.set_span(span);
-    tokens.extend(iter::once(TokenTree::Literal(literal)));
+    if repr.ends_with('e') {
+        parse_spanned(tokens, span, repr);
+    } else {
+        let mut literal: Literal = repr.parse().expect("invalid literal");
+        literal.set_span(span);
+        tokens.extend(iter::once(TokenTree::Literal(literal)));
+    }
 }
 
 macro_rules! push_punct {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -230,6 +230,34 @@ fn test_string() {
 }
 
 #[test]
+fn test_interpolated_literal() {
+    macro_rules! m {
+        ($literal:literal) => {
+            quote!($literal)
+        };
+    }
+
+    let tokens = m!(1);
+    let expected = "1";
+    assert_eq!(expected, tokens.to_string());
+
+    let tokens = m!(-1);
+    let expected = "- 1";
+    assert_eq!(expected, tokens.to_string());
+
+    // FIXME
+    /*
+    let tokens = m!(true);
+    let expected = "true";
+    assert_eq!(expected, tokens.to_string());
+
+    let tokens = m!(-true);
+    let expected = "- true";
+    assert_eq!(expected, tokens.to_string());
+    */
+}
+
+#[test]
 fn test_ident() {
     let foo = Ident::new("Foo", Span::call_site());
     let bar = Ident::new(&format!("Bar{}", 7), Span::call_site());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -245,8 +245,6 @@ fn test_interpolated_literal() {
     let expected = "- 1";
     assert_eq!(expected, tokens.to_string());
 
-    // FIXME
-    /*
     let tokens = m!(true);
     let expected = "true";
     assert_eq!(expected, tokens.to_string());
@@ -254,7 +252,6 @@ fn test_interpolated_literal() {
     let tokens = m!(-true);
     let expected = "- true";
     assert_eq!(expected, tokens.to_string());
-    */
 }
 
 #[test]


### PR DESCRIPTION
It's not entirely correct in #195 to treat arbitrary `$literal` as a `proc_macro2::Literal`. In particular, `macro_rules!`'s `$literal` matcher also matches `true`, `-true`, `false`, `-false` which are not considered valid values for a Literal in the procedural macro API.