### PR TITLE
Skip reparse on construction of Literal token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,8 @@ members = ["benches"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+# FIXME: Remove once proc-macro2 has published version 1.0.36. Publish is stuck
+# on GitHub Actions being broken today (2021-12-26).
+[patch.crates-io]
+proc-macro2 = { git = "https://github.com/dtolnay/proc-macro2" }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -284,7 +284,7 @@ pub fn push_literal(tokens: &mut TokenStream, repr: &str) {
     if repr.ends_with('e') {
         parse(tokens, repr);
     } else {
-        let literal: Literal = repr.parse().expect("invalid literal");
+        let literal = unsafe { Literal::from_str_unchecked(repr) };
         tokens.extend(iter::once(TokenTree::Literal(literal)));
     }
 }
@@ -293,7 +293,7 @@ pub fn push_literal_spanned(tokens: &mut TokenStream, span: Span, repr: &str) {
     if repr.ends_with('e') {
         parse_spanned(tokens, span, repr);
     } else {
-        let mut literal: Literal = repr.parse().expect("invalid literal");
+        let mut literal = unsafe { Literal::from_str_unchecked(repr) };
         literal.set_span(span);
         tokens.extend(iter::once(TokenTree::Literal(literal)));
     }


### PR DESCRIPTION
Follow-up to #195 using the `from_str_unchecked` function added to proc-macro2 in https://github.com/dtolnay/proc-macro2/pull/317.

I haven't published the proc-macro2 change yet because GitHub Actions is busted today, so this PR temporarily switches the proc-macro2 dependency to use the proc-macro2 git repo.