### PR TITLE
Recognize underscore token to avoid slow path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1074,6 +1074,10 @@ macro_rules! quote_token {
         $crate::__private::push_literal(&mut $tokens, stringify!($literal));
     };
 
+    ($tokens:ident _) => {
+        $crate::__private::push_underscore(&mut $tokens);
+    };
+
     ($tokens:ident $other:tt) => {
         $crate::__private::parse(&mut $tokens, stringify!($other));
     };
@@ -1295,6 +1299,10 @@ macro_rules! quote_token_spanned {
 
     ($tokens:ident $span:ident $literal:literal) => {
         $crate::__private::push_literal_spanned(&mut $tokens, $span, stringify!($literal));
+    };
+
+    ($tokens:ident $span:ident _) => {
+        $crate::__private::push_underscore_spanned(&mut $tokens, $span);
     };
 
     ($tokens:ident $span:ident $other:tt) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -396,6 +396,14 @@ push_punct!(push_star push_star_spanned '*');
 push_punct!(push_sub push_sub_spanned '-');
 push_punct!(push_sub_eq push_sub_eq_spanned '-' '=');
 
+pub fn push_underscore(tokens: &mut TokenStream) {
+    push_underscore_spanned(tokens, Span::call_site());
+}
+
+pub fn push_underscore_spanned(tokens: &mut TokenStream, span: Span) {
+    tokens.append(Ident::new("_", span));
+}
+
 // Helper method for constructing identifiers from the `format_ident!` macro,
 // handling `r#` prefixes.
 //

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -264,6 +264,13 @@ fn test_ident() {
 }
 
 #[test]
+fn test_underscore() {
+    let tokens = quote!(let _;);
+    let expected = "let _ ;";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
 fn test_duplicate() {
     let ch = 'x';
 


### PR DESCRIPTION
It turns out `_` is one of very few things still hitting the parser-based slow path after the recent optimizations for literals and lifetimes. Although `_` is considered an Ident by the proc macro API, it does not match macro_rules's $:ident matcher and must be treated separately.