### PR TITLE
Recursively respan tokens interpolated from a macro_rules metavariable

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -184,10 +184,24 @@ pub fn parse(tokens: &mut TokenStream, s: &str) {
 
 pub fn parse_spanned(tokens: &mut TokenStream, span: Span, s: &str) {
     let s: TokenStream = s.parse().expect("invalid token stream");
-    tokens.extend(s.into_iter().map(|mut t| {
-        t.set_span(span);
-        t
-    }));
+    tokens.extend(s.into_iter().map(|t| respan_token_tree(t, span)));
+}
+
+// Token tree with every span replaced by the given one.
+fn respan_token_tree(mut token: TokenTree, span: Span) -> TokenTree {
+    match &mut token {
+        TokenTree::Group(g) => {
+            let stream = g
+                .stream()
+                .into_iter()
+                .map(|token| respan_token_tree(token, span))
+                .collect();
+            *g = Group::new(g.delimiter(), stream);
+            g.set_span(span);
+        }
+        other => other.set_span(span),
+    }
+    token
 }
 
 pub fn push_ident(tokens: &mut TokenStream, s: &str) {


### PR DESCRIPTION
Repro:

```rust
macro_rules! repro {
    ($span:expr=> $expr:expr) => {
        quote_spanned!($span=> $expr)
    };
}
```

Previously an invocation like `repro!(span=> a + (b))` would set the specified `span` on the top-level tokens only, i.e. `a` and `+` and the paren token, but *not* on the `b` token.