### PR TITLE
Fix Pattern trait unimplemented for [char; 2]

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -317,7 +317,7 @@ fn is_boolean_literal(mut repr: &str) -> bool {
     if repr.starts_with('-') {
         repr = &repr[1..];
     }
-    repr.starts_with(&['t', 'f'])
+    repr.starts_with(['t', 'f'].as_slice())
 }
 
 macro_rules! push_punct {


### PR DESCRIPTION
Old standard libraries don't have this impl.

```console
error[E0277]: expected a `Fn<(char,)>` closure, found `[char; 2]`
   --> src/runtime.rs:320:22
    |
320 |     repr.starts_with(&['t', 'f'])
    |          ----------- ^^^^^^^^^^^ expected an `Fn<(char,)>` closure, found `[char; 2]`
    |          |
    |          required by a bound introduced by this call
    |
    = help: the trait `Fn<(char,)>` is not implemented for `[char; 2]`
    = note: required because of the requirements on the impl of `FnOnce<(char,)>` for `&[char; 2]`
    = note: required because of the requirements on the impl of `Pattern<'_>` for `&[char; 2]`
```

GitHub Actions was down yesterday so this didn't get caught in CI.