### PR TITLE
Fix no as_slice() on arrays on old toolchains

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -317,7 +317,7 @@ fn is_boolean_literal(mut repr: &str) -> bool {
     if repr.starts_with('-') {
         repr = &repr[1..];
     }
-    repr.starts_with(['t', 'f'].as_slice())
+    repr.starts_with(&['t', 'f'][..])
 }
 
 macro_rules! push_punct {


### PR DESCRIPTION
Pre-1.57:

```console
error[E0658]: use of unstable library feature 'array_methods'
   --> src/runtime.rs:320:33
    |
320 |     repr.starts_with(['t', 'f'].as_slice())
    |                                 ^^^^^^^^
    |
    = note: see issue #76118 <https://github.com/rust-lang/rust/issues/76118> for more information
```

Pre-1.48:

```console
error[E0599]: no method named `as_slice` found for array `[char; 2]` in the current scope
   --> src/runtime.rs:320:33
    |
320 |     repr.starts_with(['t', 'f'].as_slice())
    |                                 ^^^^^^^^ method not found in `[char; 2]`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use std::array::FixedSizeArray;`
```