### PR TITLE
Restore support for toolchains without $:literal matcher

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,30 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+// The rustc-cfg strings below are *not* public API. Please let us know by
+// opening a GitHub issue if your build environment requires some way to enable
+// these cfgs other than by executing our build script.
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    // The $:literal matcher in macro_rules stabilized in 1.32:
+    // https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html#macro-improvements
+    if minor < 32 {
+        println!("cargo:rustc-cfg=no_literal_matcher");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1070,14 +1070,32 @@ macro_rules! quote_token {
         $crate::__private::push_lifetime(&mut $tokens, stringify!($lifetime));
     };
 
-    ($tokens:ident $literal:literal) => {
-        $crate::__private::push_literal(&mut $tokens, stringify!($literal));
-    };
-
     ($tokens:ident _) => {
         $crate::__private::push_underscore(&mut $tokens);
     };
 
+    ($tokens:ident $other:tt) => {
+        $crate::quote_literal_or_token!($tokens $other);
+    };
+}
+
+#[cfg(not(no_literal_matcher))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! quote_literal_or_token {
+    ($tokens:ident $literal:literal) => {
+        $crate::__private::push_literal(&mut $tokens, stringify!($literal));
+    };
+
+    ($tokens:ident $other:tt) => {
+        $crate::__private::parse(&mut $tokens, stringify!($other));
+    };
+}
+
+#[cfg(no_literal_matcher)]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! quote_literal_or_token {
     ($tokens:ident $other:tt) => {
         $crate::__private::parse(&mut $tokens, stringify!($other));
     };
@@ -1297,14 +1315,32 @@ macro_rules! quote_token_spanned {
         $crate::__private::push_lifetime_spanned(&mut $tokens, $span, stringify!($lifetime));
     };
 
-    ($tokens:ident $span:ident $literal:literal) => {
-        $crate::__private::push_literal_spanned(&mut $tokens, $span, stringify!($literal));
-    };
-
     ($tokens:ident $span:ident _) => {
         $crate::__private::push_underscore_spanned(&mut $tokens, $span);
     };
 
+    ($tokens:ident $span:ident $other:tt) => {
+        $crate::quote_literal_or_token_spanned!($tokens $span $other);
+    };
+}
+
+#[cfg(not(no_literal_matcher))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! quote_literal_or_token_spanned {
+    ($tokens:ident $span:ident $literal:literal) => {
+        $crate::__private::push_literal_spanned(&mut $tokens, $span, stringify!($literal));
+    };
+
+    ($tokens:ident $span:ident $other:tt) => {
+        $crate::__private::parse_spanned(&mut $tokens, $span, stringify!($other));
+    };
+}
+
+#[cfg(no_literal_matcher)]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! quote_literal_or_token_spanned {
     ($tokens:ident $span:ident $other:tt) => {
         $crate::__private::parse_spanned(&mut $tokens, $span, stringify!($other));
     };


### PR DESCRIPTION
The $:literal matcher in macro_rules stabilized in Rust 1.32: https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html#macro-improvements.