### PR TITLE
chore: update to rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ documentation = "https://docs.rs/quote/"
 keywords = ["syn"]
 categories = ["development-tools::procedural-macro-helpers"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 autobenches = false
-rust-version = "1.31"
+rust-version = "1.56.0"
 
 [dependencies]
 proc-macro2 = { version = "1.0.36", default-features = false }
 
 [dev-dependencies]
-rustversion = "1.0"
-trybuild = { version = "1.0.52", features = ["diff"] }
+rustversion = "1.0.6"
+trybuild = { version = "1.0.53", features = ["diff"] }
 
 [features]
 default = ["proc-macro"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -3,7 +3,7 @@ name = "quote-benchmark"
 version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ pub mod spanned;
 /// #
 /// // incorrect
 /// quote! {
-///     let mut _#ident = 0;
+///     let mut _ #ident = 0;
 /// }
 /// # ;
 /// ```


### PR DESCRIPTION
Just got to know quote by looking at a dependency tree of a project and saw that the cargo definition featured rust 2018 edition.

Did:
- `Cargo fix --edition`
- Updated `edition` in _Cargo.toml_ to 2021
- Ran all tests
- Ran benches

Happy new year 🥂 