### PR TITLE
Order rules in `quote_token!` and `quote_token_spanned!` by frequency.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,9 +859,21 @@ macro_rules! quote_token_with_context_spanned {
     };
 }
 
+// These rules are ordered by approximate token frequency, at least for the
+// first 10 or so, to improve compile times. Having `ident` first is by far the
+// most important, because it's typically 2-3x more common than the next most
+// common token.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! quote_token {
+    ($tokens:ident $ident:ident) => {
+        $crate::__private::push_ident(&mut $tokens, stringify!($ident));
+    };
+
+    ($tokens:ident ::) => {
+        $crate::__private::push_colon2(&mut $tokens);
+    };
+
     ($tokens:ident ( $($inner:tt)* )) => {
         $crate::__private::push_group(
             &mut $tokens,
@@ -884,6 +896,26 @@ macro_rules! quote_token {
             $crate::__private::Delimiter::Brace,
             $crate::quote!($($inner)*),
         );
+    };
+
+    ($tokens:ident #) => {
+        $crate::__private::push_pound(&mut $tokens);
+    };
+
+    ($tokens:ident ,) => {
+        $crate::__private::push_comma(&mut $tokens);
+    };
+
+    ($tokens:ident .) => {
+        $crate::__private::push_dot(&mut $tokens);
+    };
+
+    ($tokens:ident ;) => {
+        $crate::__private::push_semi(&mut $tokens);
+    };
+
+    ($tokens:ident :) => {
+        $crate::__private::push_colon(&mut $tokens);
     };
 
     ($tokens:ident +) => {
@@ -922,28 +954,12 @@ macro_rules! quote_token {
         $crate::__private::push_caret_eq(&mut $tokens);
     };
 
-    ($tokens:ident :) => {
-        $crate::__private::push_colon(&mut $tokens);
-    };
-
-    ($tokens:ident ::) => {
-        $crate::__private::push_colon2(&mut $tokens);
-    };
-
-    ($tokens:ident ,) => {
-        $crate::__private::push_comma(&mut $tokens);
-    };
-
     ($tokens:ident /) => {
         $crate::__private::push_div(&mut $tokens);
     };
 
     ($tokens:ident /=) => {
         $crate::__private::push_div_eq(&mut $tokens);
-    };
-
-    ($tokens:ident .) => {
-        $crate::__private::push_dot(&mut $tokens);
     };
 
     ($tokens:ident ..) => {
@@ -1002,10 +1018,6 @@ macro_rules! quote_token {
         $crate::__private::push_or_or(&mut $tokens);
     };
 
-    ($tokens:ident #) => {
-        $crate::__private::push_pound(&mut $tokens);
-    };
-
     ($tokens:ident ?) => {
         $crate::__private::push_question(&mut $tokens);
     };
@@ -1028,10 +1040,6 @@ macro_rules! quote_token {
 
     ($tokens:ident =>) => {
         $crate::__private::push_fat_arrow(&mut $tokens);
-    };
-
-    ($tokens:ident ;) => {
-        $crate::__private::push_semi(&mut $tokens);
     };
 
     ($tokens:ident <<) => {
@@ -1062,10 +1070,6 @@ macro_rules! quote_token {
         $crate::__private::push_sub_eq(&mut $tokens);
     };
 
-    ($tokens:ident $ident:ident) => {
-        $crate::__private::push_ident(&mut $tokens, stringify!($ident));
-    };
-
     ($tokens:ident $lifetime:lifetime) => {
         $crate::__private::push_lifetime(&mut $tokens, stringify!($lifetime));
     };
@@ -1079,9 +1083,18 @@ macro_rules! quote_token {
     };
 }
 
+// See the comment above `quote_token!` about the rule ordering.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! quote_token_spanned {
+    ($tokens:ident $span:ident $ident:ident) => {
+        $crate::__private::push_ident_spanned(&mut $tokens, $span, stringify!($ident));
+    };
+
+    ($tokens:ident $span:ident ::) => {
+        $crate::__private::push_colon2_spanned(&mut $tokens, $span);
+    };
+
     ($tokens:ident $span:ident ( $($inner:tt)* )) => {
         $crate::__private::push_group_spanned(
             &mut $tokens,
@@ -1107,6 +1120,26 @@ macro_rules! quote_token_spanned {
             $crate::__private::Delimiter::Brace,
             $crate::quote_spanned!($span=> $($inner)*),
         );
+    };
+
+    ($tokens:ident $span:ident #) => {
+        $crate::__private::push_pound_spanned(&mut $tokens, $span);
+    };
+
+    ($tokens:ident $span:ident ,) => {
+        $crate::__private::push_comma_spanned(&mut $tokens, $span);
+    };
+
+    ($tokens:ident $span:ident .) => {
+        $crate::__private::push_dot_spanned(&mut $tokens, $span);
+    };
+
+    ($tokens:ident $span:ident ;) => {
+        $crate::__private::push_semi_spanned(&mut $tokens, $span);
+    };
+
+    ($tokens:ident $span:ident :) => {
+        $crate::__private::push_colon_spanned(&mut $tokens, $span);
     };
 
     ($tokens:ident $span:ident +) => {
@@ -1145,28 +1178,12 @@ macro_rules! quote_token_spanned {
         $crate::__private::push_caret_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident :) => {
-        $crate::__private::push_colon_spanned(&mut $tokens, $span);
-    };
-
-    ($tokens:ident $span:ident ::) => {
-        $crate::__private::push_colon2_spanned(&mut $tokens, $span);
-    };
-
-    ($tokens:ident $span:ident ,) => {
-        $crate::__private::push_comma_spanned(&mut $tokens, $span);
-    };
-
     ($tokens:ident $span:ident /) => {
         $crate::__private::push_div_spanned(&mut $tokens, $span);
     };
 
     ($tokens:ident $span:ident /=) => {
         $crate::__private::push_div_eq_spanned(&mut $tokens, $span);
-    };
-
-    ($tokens:ident $span:ident .) => {
-        $crate::__private::push_dot_spanned(&mut $tokens, $span);
     };
 
     ($tokens:ident $span:ident ..) => {
@@ -1225,10 +1242,6 @@ macro_rules! quote_token_spanned {
         $crate::__private::push_or_or_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident #) => {
-        $crate::__private::push_pound_spanned(&mut $tokens, $span);
-    };
-
     ($tokens:ident $span:ident ?) => {
         $crate::__private::push_question_spanned(&mut $tokens, $span);
     };
@@ -1251,10 +1264,6 @@ macro_rules! quote_token_spanned {
 
     ($tokens:ident $span:ident =>) => {
         $crate::__private::push_fat_arrow_spanned(&mut $tokens, $span);
-    };
-
-    ($tokens:ident $span:ident ;) => {
-        $crate::__private::push_semi_spanned(&mut $tokens, $span);
     };
 
     ($tokens:ident $span:ident <<) => {
@@ -1283,10 +1292,6 @@ macro_rules! quote_token_spanned {
 
     ($tokens:ident $span:ident -=) => {
         $crate::__private::push_sub_eq_spanned(&mut $tokens, $span);
-    };
-
-    ($tokens:ident $span:ident $ident:ident) => {
-        $crate::__private::push_ident_spanned(&mut $tokens, $span, stringify!($ident));
     };
 
     ($tokens:ident $span:ident $lifetime:lifetime) => {


### PR DESCRIPTION
This reduces `cargo check` times by 4-9% on a few crates that use
`quote!` heavily.