### PR TITLE
Reorder arguments in `quote_token` and `quote_token_spanned`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,7 +762,7 @@ macro_rules! quote_token_with_context {
         while true {
             $crate::pounded_var_names!(quote_bind_next_or_break!() () $($inner)*);
             if _i > 0 {
-                $crate::quote_token!($tokens $sep);
+                $crate::quote_token!($sep $tokens);
             }
             _i += 1;
             $crate::quote_each_token!($tokens $($inner)*);
@@ -772,7 +772,7 @@ macro_rules! quote_token_with_context {
     ($tokens:ident $b3:tt # ( $($inner:tt)* ) ($sep:tt) * $a2:tt $a3:tt) => {};
     ($tokens:ident # ( $($inner:tt)* ) * (*) $a1:tt $a2:tt $a3:tt) => {
         // https://github.com/dtolnay/quote/issues/130
-        $crate::quote_token!($tokens *);
+        $crate::quote_token!(* $tokens);
     };
     ($tokens:ident # ( $($inner:tt)* ) $sep:tt (*) $a1:tt $a2:tt $a3:tt) => {};
 
@@ -781,7 +781,7 @@ macro_rules! quote_token_with_context {
     };
     ($tokens:ident $b3:tt $b2:tt # ($var:ident) $a1:tt $a2:tt $a3:tt) => {};
     ($tokens:ident $b3:tt $b2:tt $b1:tt ($curr:tt) $a1:tt $a2:tt $a3:tt) => {
-        $crate::quote_token!($tokens $curr);
+        $crate::quote_token!($curr $tokens);
     };
 }
 
@@ -848,15 +848,15 @@ macro_rules! quote_token_with_context_spanned {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! quote_token {
-    ($tokens:ident $ident:ident) => {
+    ($ident:ident $tokens:ident) => {
         $crate::__private::push_ident(&mut $tokens, stringify!($ident));
     };
 
-    ($tokens:ident ::) => {
+    (:: $tokens:ident) => {
         $crate::__private::push_colon2(&mut $tokens);
     };
 
-    ($tokens:ident ( $($inner:tt)* )) => {
+    (( $($inner:tt)* ) $tokens:ident) => {
         $crate::__private::push_group(
             &mut $tokens,
             $crate::__private::Delimiter::Parenthesis,
@@ -864,7 +864,7 @@ macro_rules! quote_token {
         );
     };
 
-    ($tokens:ident [ $($inner:tt)* ]) => {
+    ([ $($inner:tt)* ] $tokens:ident) => {
         $crate::__private::push_group(
             &mut $tokens,
             $crate::__private::Delimiter::Bracket,
@@ -872,7 +872,7 @@ macro_rules! quote_token {
         );
     };
 
-    ($tokens:ident { $($inner:tt)* }) => {
+    ({ $($inner:tt)* } $tokens:ident) => {
         $crate::__private::push_group(
             &mut $tokens,
             $crate::__private::Delimiter::Brace,
@@ -880,187 +880,187 @@ macro_rules! quote_token {
         );
     };
 
-    ($tokens:ident #) => {
+    (# $tokens:ident) => {
         $crate::__private::push_pound(&mut $tokens);
     };
 
-    ($tokens:ident ,) => {
+    (, $tokens:ident) => {
         $crate::__private::push_comma(&mut $tokens);
     };
 
-    ($tokens:ident .) => {
+    (. $tokens:ident) => {
         $crate::__private::push_dot(&mut $tokens);
     };
 
-    ($tokens:ident ;) => {
+    (; $tokens:ident) => {
         $crate::__private::push_semi(&mut $tokens);
     };
 
-    ($tokens:ident :) => {
+    (: $tokens:ident) => {
         $crate::__private::push_colon(&mut $tokens);
     };
 
-    ($tokens:ident +) => {
+    (+ $tokens:ident) => {
         $crate::__private::push_add(&mut $tokens);
     };
 
-    ($tokens:ident +=) => {
+    (+= $tokens:ident) => {
         $crate::__private::push_add_eq(&mut $tokens);
     };
 
-    ($tokens:ident &) => {
+    (& $tokens:ident) => {
         $crate::__private::push_and(&mut $tokens);
     };
 
-    ($tokens:ident &&) => {
+    (&& $tokens:ident) => {
         $crate::__private::push_and_and(&mut $tokens);
     };
 
-    ($tokens:ident &=) => {
+    (&= $tokens:ident) => {
         $crate::__private::push_and_eq(&mut $tokens);
     };
 
-    ($tokens:ident @) => {
+    (@ $tokens:ident) => {
         $crate::__private::push_at(&mut $tokens);
     };
 
-    ($tokens:ident !) => {
+    (! $tokens:ident) => {
         $crate::__private::push_bang(&mut $tokens);
     };
 
-    ($tokens:ident ^) => {
+    (^ $tokens:ident) => {
         $crate::__private::push_caret(&mut $tokens);
     };
 
-    ($tokens:ident ^=) => {
+    (^= $tokens:ident) => {
         $crate::__private::push_caret_eq(&mut $tokens);
     };
 
-    ($tokens:ident /) => {
+    (/ $tokens:ident) => {
         $crate::__private::push_div(&mut $tokens);
     };
 
-    ($tokens:ident /=) => {
+    (/= $tokens:ident) => {
         $crate::__private::push_div_eq(&mut $tokens);
     };
 
-    ($tokens:ident ..) => {
+    (.. $tokens:ident) => {
         $crate::__private::push_dot2(&mut $tokens);
     };
 
-    ($tokens:ident ...) => {
+    (... $tokens:ident) => {
         $crate::__private::push_dot3(&mut $tokens);
     };
 
-    ($tokens:ident ..=) => {
+    (..= $tokens:ident) => {
         $crate::__private::push_dot_dot_eq(&mut $tokens);
     };
 
-    ($tokens:ident =) => {
+    (= $tokens:ident) => {
         $crate::__private::push_eq(&mut $tokens);
     };
 
-    ($tokens:ident ==) => {
+    (== $tokens:ident) => {
         $crate::__private::push_eq_eq(&mut $tokens);
     };
 
-    ($tokens:ident >=) => {
+    (>= $tokens:ident) => {
         $crate::__private::push_ge(&mut $tokens);
     };
 
-    ($tokens:ident >) => {
+    (> $tokens:ident) => {
         $crate::__private::push_gt(&mut $tokens);
     };
 
-    ($tokens:ident <=) => {
+    (<= $tokens:ident) => {
         $crate::__private::push_le(&mut $tokens);
     };
 
-    ($tokens:ident <) => {
+    (< $tokens:ident) => {
         $crate::__private::push_lt(&mut $tokens);
     };
 
-    ($tokens:ident *=) => {
+    (*= $tokens:ident) => {
         $crate::__private::push_mul_eq(&mut $tokens);
     };
 
-    ($tokens:ident !=) => {
+    (!= $tokens:ident) => {
         $crate::__private::push_ne(&mut $tokens);
     };
 
-    ($tokens:ident |) => {
+    (| $tokens:ident) => {
         $crate::__private::push_or(&mut $tokens);
     };
 
-    ($tokens:ident |=) => {
+    (|= $tokens:ident) => {
         $crate::__private::push_or_eq(&mut $tokens);
     };
 
-    ($tokens:ident ||) => {
+    (|| $tokens:ident) => {
         $crate::__private::push_or_or(&mut $tokens);
     };
 
-    ($tokens:ident ?) => {
+    (? $tokens:ident) => {
         $crate::__private::push_question(&mut $tokens);
     };
 
-    ($tokens:ident ->) => {
+    (-> $tokens:ident) => {
         $crate::__private::push_rarrow(&mut $tokens);
     };
 
-    ($tokens:ident <-) => {
+    (<- $tokens:ident) => {
         $crate::__private::push_larrow(&mut $tokens);
     };
 
-    ($tokens:ident %) => {
+    (% $tokens:ident) => {
         $crate::__private::push_rem(&mut $tokens);
     };
 
-    ($tokens:ident %=) => {
+    (%= $tokens:ident) => {
         $crate::__private::push_rem_eq(&mut $tokens);
     };
 
-    ($tokens:ident =>) => {
+    (=> $tokens:ident) => {
         $crate::__private::push_fat_arrow(&mut $tokens);
     };
 
-    ($tokens:ident <<) => {
+    (<< $tokens:ident) => {
         $crate::__private::push_shl(&mut $tokens);
     };
 
-    ($tokens:ident <<=) => {
+    (<<= $tokens:ident) => {
         $crate::__private::push_shl_eq(&mut $tokens);
     };
 
-    ($tokens:ident >>) => {
+    (>> $tokens:ident) => {
         $crate::__private::push_shr(&mut $tokens);
     };
 
-    ($tokens:ident >>=) => {
+    (>>= $tokens:ident) => {
         $crate::__private::push_shr_eq(&mut $tokens);
     };
 
-    ($tokens:ident *) => {
+    (* $tokens:ident) => {
         $crate::__private::push_star(&mut $tokens);
     };
 
-    ($tokens:ident -) => {
+    (- $tokens:ident) => {
         $crate::__private::push_sub(&mut $tokens);
     };
 
-    ($tokens:ident -=) => {
+    (-= $tokens:ident) => {
         $crate::__private::push_sub_eq(&mut $tokens);
     };
 
-    ($tokens:ident $lifetime:lifetime) => {
+    ($lifetime:lifetime $tokens:ident) => {
         $crate::__private::push_lifetime(&mut $tokens, stringify!($lifetime));
     };
 
-    ($tokens:ident _) => {
+    (_ $tokens:ident) => {
         $crate::__private::push_underscore(&mut $tokens);
     };
 
-    ($tokens:ident $other:tt) => {
+    ($other:tt $tokens:ident) => {
         $crate::__private::parse(&mut $tokens, stringify!($other));
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,7 +818,7 @@ macro_rules! quote_token_with_context_spanned {
         while true {
             $crate::pounded_var_names!(quote_bind_next_or_break!() () $($inner)*);
             if _i > 0 {
-                $crate::quote_token_spanned!($tokens $span $sep);
+                $crate::quote_token_spanned!($sep $tokens $span);
             }
             _i += 1;
             $crate::quote_each_token_spanned!($tokens $span $($inner)*);
@@ -828,7 +828,7 @@ macro_rules! quote_token_with_context_spanned {
     ($tokens:ident $span:ident $b3:tt # ( $($inner:tt)* ) ($sep:tt) * $a2:tt $a3:tt) => {};
     ($tokens:ident $span:ident # ( $($inner:tt)* ) * (*) $a1:tt $a2:tt $a3:tt) => {
         // https://github.com/dtolnay/quote/issues/130
-        $crate::quote_token_spanned!($tokens $span *);
+        $crate::quote_token_spanned!(* $tokens $span);
     };
     ($tokens:ident $span:ident # ( $($inner:tt)* ) $sep:tt (*) $a1:tt $a2:tt $a3:tt) => {};
 
@@ -837,7 +837,7 @@ macro_rules! quote_token_with_context_spanned {
     };
     ($tokens:ident $span:ident $b3:tt $b2:tt # ($var:ident) $a1:tt $a2:tt $a3:tt) => {};
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt ($curr:tt) $a1:tt $a2:tt $a3:tt) => {
-        $crate::quote_token_spanned!($tokens $span $curr);
+        $crate::quote_token_spanned!($curr $tokens $span);
     };
 }
 
@@ -1069,15 +1069,15 @@ macro_rules! quote_token {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! quote_token_spanned {
-    ($tokens:ident $span:ident $ident:ident) => {
+    ($ident:ident $tokens:ident $span:ident) => {
         $crate::__private::push_ident_spanned(&mut $tokens, $span, stringify!($ident));
     };
 
-    ($tokens:ident $span:ident ::) => {
+    (:: $tokens:ident $span:ident) => {
         $crate::__private::push_colon2_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ( $($inner:tt)* )) => {
+    (( $($inner:tt)* ) $tokens:ident $span:ident) => {
         $crate::__private::push_group_spanned(
             &mut $tokens,
             $span,
@@ -1086,7 +1086,7 @@ macro_rules! quote_token_spanned {
         );
     };
 
-    ($tokens:ident $span:ident [ $($inner:tt)* ]) => {
+    ([ $($inner:tt)* ] $tokens:ident $span:ident) => {
         $crate::__private::push_group_spanned(
             &mut $tokens,
             $span,
@@ -1095,7 +1095,7 @@ macro_rules! quote_token_spanned {
         );
     };
 
-    ($tokens:ident $span:ident { $($inner:tt)* }) => {
+    ({ $($inner:tt)* } $tokens:ident $span:ident) => {
         $crate::__private::push_group_spanned(
             &mut $tokens,
             $span,
@@ -1104,187 +1104,187 @@ macro_rules! quote_token_spanned {
         );
     };
 
-    ($tokens:ident $span:ident #) => {
+    (# $tokens:ident $span:ident) => {
         $crate::__private::push_pound_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ,) => {
+    (, $tokens:ident $span:ident) => {
         $crate::__private::push_comma_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident .) => {
+    (. $tokens:ident $span:ident) => {
         $crate::__private::push_dot_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ;) => {
+    (; $tokens:ident $span:ident) => {
         $crate::__private::push_semi_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident :) => {
+    (: $tokens:ident $span:ident) => {
         $crate::__private::push_colon_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident +) => {
+    (+ $tokens:ident $span:ident) => {
         $crate::__private::push_add_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident +=) => {
+    (+= $tokens:ident $span:ident) => {
         $crate::__private::push_add_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident &) => {
+    (& $tokens:ident $span:ident) => {
         $crate::__private::push_and_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident &&) => {
+    (&& $tokens:ident $span:ident) => {
         $crate::__private::push_and_and_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident &=) => {
+    (&= $tokens:ident $span:ident) => {
         $crate::__private::push_and_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident @) => {
+    (@ $tokens:ident $span:ident) => {
         $crate::__private::push_at_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident !) => {
+    (! $tokens:ident $span:ident) => {
         $crate::__private::push_bang_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ^) => {
+    (^ $tokens:ident $span:ident) => {
         $crate::__private::push_caret_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ^=) => {
+    (^= $tokens:ident $span:ident) => {
         $crate::__private::push_caret_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident /) => {
+    (/ $tokens:ident $span:ident) => {
         $crate::__private::push_div_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident /=) => {
+    (/= $tokens:ident $span:ident) => {
         $crate::__private::push_div_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ..) => {
+    (.. $tokens:ident $span:ident) => {
         $crate::__private::push_dot2_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ...) => {
+    (... $tokens:ident $span:ident) => {
         $crate::__private::push_dot3_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ..=) => {
+    (..= $tokens:ident $span:ident) => {
         $crate::__private::push_dot_dot_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident =) => {
+    (= $tokens:ident $span:ident) => {
         $crate::__private::push_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ==) => {
+    (== $tokens:ident $span:ident) => {
         $crate::__private::push_eq_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident >=) => {
+    (>= $tokens:ident $span:ident) => {
         $crate::__private::push_ge_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident >) => {
+    (> $tokens:ident $span:ident) => {
         $crate::__private::push_gt_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident <=) => {
+    (<= $tokens:ident $span:ident) => {
         $crate::__private::push_le_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident <) => {
+    (< $tokens:ident $span:ident) => {
         $crate::__private::push_lt_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident *=) => {
+    (*= $tokens:ident $span:ident) => {
         $crate::__private::push_mul_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident !=) => {
+    (!= $tokens:ident $span:ident) => {
         $crate::__private::push_ne_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident |) => {
+    (| $tokens:ident $span:ident) => {
         $crate::__private::push_or_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident |=) => {
+    (|= $tokens:ident $span:ident) => {
         $crate::__private::push_or_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ||) => {
+    (|| $tokens:ident $span:ident) => {
         $crate::__private::push_or_or_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ?) => {
+    (? $tokens:ident $span:ident) => {
         $crate::__private::push_question_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident ->) => {
+    (-> $tokens:ident $span:ident) => {
         $crate::__private::push_rarrow_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident <-) => {
+    (<- $tokens:ident $span:ident) => {
         $crate::__private::push_larrow_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident %) => {
+    (% $tokens:ident $span:ident) => {
         $crate::__private::push_rem_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident %=) => {
+    (%= $tokens:ident $span:ident) => {
         $crate::__private::push_rem_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident =>) => {
+    (=> $tokens:ident $span:ident) => {
         $crate::__private::push_fat_arrow_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident <<) => {
+    (<< $tokens:ident $span:ident) => {
         $crate::__private::push_shl_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident <<=) => {
+    (<<= $tokens:ident $span:ident) => {
         $crate::__private::push_shl_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident >>) => {
+    (>> $tokens:ident $span:ident) => {
         $crate::__private::push_shr_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident >>=) => {
+    (>>= $tokens:ident $span:ident) => {
         $crate::__private::push_shr_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident *) => {
+    (* $tokens:ident $span:ident) => {
         $crate::__private::push_star_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident -) => {
+    (- $tokens:ident $span:ident) => {
         $crate::__private::push_sub_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident -=) => {
+    (-= $tokens:ident $span:ident) => {
         $crate::__private::push_sub_eq_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident $lifetime:lifetime) => {
+    ($lifetime:lifetime $tokens:ident $span:ident) => {
         $crate::__private::push_lifetime_spanned(&mut $tokens, $span, stringify!($lifetime));
     };
 
-    ($tokens:ident $span:ident _) => {
+    (_ $tokens:ident $span:ident) => {
         $crate::__private::push_underscore_spanned(&mut $tokens, $span);
     };
 
-    ($tokens:ident $span:ident $other:tt) => {
+    ($other:tt $tokens:ident $span:ident) => {
         $crate::__private::parse_spanned(&mut $tokens, $span, stringify!($other));
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -842,9 +842,9 @@ macro_rules! quote_token_with_context_spanned {
 }
 
 // These rules are ordered by approximate token frequency, at least for the
-// first 10 or so, to improve compile times. Having `ident` first is by far the
-// most important, because it's typically 2-3x more common than the next most
-// common token.
+// first 10 or so, to improve compile times. Similarly, having the `$tokens` at
+// the end allows for failing rules to fail as quickly as possible, and also helps
+// reduce compile times for crates that use `quote!` heavily.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! quote_token {


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/dtolnay/quote/pull/209#pullrequestreview-912775088 to reorder the arguments to these macros, and avoid some parsing of idents during rule matching.

The tests succeed but I'm not familiar with `quote`'s internals, and may have made a mistake, especially on the more complicated rules.

If it's correct, this would result in a small improvement:

<html><body>
<!--StartFragment-->

Benchmark & Profile | Scenario | % Change | Significance Factor                 ?
-- | -- | -- | --
ctor-0.1.21 check | incr-unchanged | -3.00% | 15.00x
pest_generator-2.1.3 check | incr-unchanged | -2.20% | 11.02x
num-derive-0.3.3 check | incr-unchanged | -2.05% | 10.25x
ctor-0.1.21 check | full | -1.88% | 9.39x
mockall_derive-0.11.0 check | incr-unchanged | -1.82% | 9.08x
ctor-0.1.21 check | incr-full | -1.64% | 8.21x
scroll_derive-0.11.0 check | incr-unchanged | -1.56% | 7.82x
pest_generator-2.1.3 check | full | -1.32% | 6.59x
num-derive-0.3.3 check | full | -1.19% | 5.97x
futures-macro-0.3.19 check | incr-unchanged | -1.19% | 5.97x
pest_generator-2.1.3 check | incr-full | -1.14% | 5.70x
num-derive-0.3.3 check | incr-full | -1.09% | 5.47x
mockall_derive-0.11.0 check | full | -0.94% | 4.72x
scroll_derive-0.11.0 check | full | -0.85% | 4.26x
mockall_derive-0.11.0 check | incr-full | -0.78% | 3.91x
scroll_derive-0.11.0 check | incr-full | -0.69% | 3.44x
futures-macro-0.3.19 check | incr-full | 0.05% | 0.27x
futures-macro-0.3.19 check | full | -0.04% | 0.21x

<!--EndFragment-->
</body>
</html>