### PR TITLE
Remove part about `concat!` from doc comment example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,14 +389,6 @@ pub mod spanned;
 /// }
 /// ```
 ///
-/// Macro calls in a doc attribute are not valid syntax:
-///
-/// ```compile_fail
-/// quote! {
-///     #[doc = concat!("try to interpolate: ", stringify!(#ident))]
-/// }
-/// ```
-///
 /// Instead the best way to build doc comments that involve variables is by
 /// formatting the doc string literal outside of quote.
 ///


### PR DESCRIPTION
That way now works since Rust 1.54 (https://github.com/rust-lang/rust/pull/83366). Even so, using `format!` outside the `quote!` invocation is still usually the way to go.