### PR TITLE
Use a character other than \0 for testing unicode escapes

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -200,7 +200,7 @@ fn test_floating() {
 
 #[test]
 fn test_char() {
-    let zero = '\0';
+    let zero = '\u{1}';
     let pound = '#';
     let quote = '"';
     let apost = '\'';
@@ -210,23 +210,23 @@ fn test_char() {
     let tokens = quote! {
         #zero #pound #quote #apost #newline #heart
     };
-    let expected = "'\\u{0}' '#' '\"' '\\'' '\\n' '\u{2764}'";
+    let expected = "'\\u{1}' '#' '\"' '\\'' '\\n' '\u{2764}'";
     assert_eq!(expected, tokens.to_string());
 }
 
 #[test]
 fn test_str() {
-    let s = "\0 a 'b \" c";
+    let s = "\u{1} a 'b \" c";
     let tokens = quote!(#s);
-    let expected = "\"\\u{0} a 'b \\\" c\"";
+    let expected = "\"\\u{1} a 'b \\\" c\"";
     assert_eq!(expected, tokens.to_string());
 }
 
 #[test]
 fn test_string() {
-    let s = "\0 a 'b \" c".to_string();
+    let s = "\u{1} a 'b \" c".to_string();
     let tokens = quote!(#s);
-    let expected = "\"\\u{0} a 'b \\\" c\"";
+    let expected = "\"\\u{1} a 'b \\\" c\"";
     assert_eq!(expected, tokens.to_string());
 }
 


### PR DESCRIPTION
As of https://github.com/rust-lang/rust/pull/95345, character 0 is rendered as `'\0'` by libproc_macro. This PR switches the char and string tests to a different codepoint so that the test works the same across all supported compiler versions.