### PR TITLE
Eliminate piles of extra semicolons from expanded code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,7 @@ macro_rules! quote {
     // Special case rule for a single tt, for performance.
     ($tt:tt) => {{
         let mut _s = $crate::__private::TokenStream::new();
-        $crate::quote_token!($tt _s);
+        $crate::quote_token!{$tt _s}
         _s
     }};
 
@@ -498,15 +498,15 @@ macro_rules! quote {
     }};
     ($tt1:tt $tt2:tt) => {{
         let mut _s = $crate::__private::TokenStream::new();
-        $crate::quote_token!($tt1 _s);
-        $crate::quote_token!($tt2 _s);
+        $crate::quote_token!{$tt1 _s}
+        $crate::quote_token!{$tt2 _s}
         _s
     }};
 
     // Rule for any other number of tokens.
     ($($tt:tt)*) => {{
         let mut _s = $crate::__private::TokenStream::new();
-        $crate::quote_each_token!(_s $($tt)*);
+        $crate::quote_each_token!{_s $($tt)*}
         _s
     }};
 }
@@ -627,7 +627,7 @@ macro_rules! quote_spanned {
     ($span:expr=> $tt:tt) => {{
         let mut _s = $crate::__private::TokenStream::new();
         let _span: $crate::__private::Span = $span;
-        $crate::quote_token_spanned!($tt _s _span);
+        $crate::quote_token_spanned!{$tt _s _span}
         _s
     }};
 
@@ -641,8 +641,8 @@ macro_rules! quote_spanned {
     ($span:expr=> $tt1:tt $tt2:tt) => {{
         let mut _s = $crate::__private::TokenStream::new();
         let _span: $crate::__private::Span = $span;
-        $crate::quote_token_spanned!($tt1 _s _span);
-        $crate::quote_token_spanned!($tt2 _s _span);
+        $crate::quote_token_spanned!{$tt1 _s _span}
+        $crate::quote_token_spanned!{$tt2 _s _span}
         _s
     }};
 
@@ -650,7 +650,7 @@ macro_rules! quote_spanned {
     ($span:expr=> $($tt:tt)*) => {{
         let mut _s = $crate::__private::TokenStream::new();
         let _span: $crate::__private::Span = $span;
-        $crate::quote_each_token_spanned!(_s _span $($tt)*);
+        $crate::quote_each_token_spanned!{_s _span $($tt)*}
         _s
     }};
 }
@@ -665,10 +665,10 @@ macro_rules! quote_spanned {
 #[doc(hidden)]
 macro_rules! pounded_var_names {
     ($call:ident! $extra:tt $($tts:tt)*) => {
-        $crate::pounded_var_names_with_context!($call! $extra
+        $crate::pounded_var_names_with_context!{$call! $extra
             (@ $($tts)*)
             ($($tts)* @)
-        )
+        }
     };
 }
 
@@ -677,7 +677,7 @@ macro_rules! pounded_var_names {
 macro_rules! pounded_var_names_with_context {
     ($call:ident! $extra:tt ($($b1:tt)*) ($($curr:tt)*)) => {
         $(
-            $crate::pounded_var_with_context!($call! $extra $b1 $curr);
+            $crate::pounded_var_with_context!{$call! $extra $b1 $curr}
         )*
     };
 }
@@ -686,15 +686,15 @@ macro_rules! pounded_var_names_with_context {
 #[doc(hidden)]
 macro_rules! pounded_var_with_context {
     ($call:ident! $extra:tt $b1:tt ( $($inner:tt)* )) => {
-        $crate::pounded_var_names!($call! $extra $($inner)*);
+        $crate::pounded_var_names!{$call! $extra $($inner)*}
     };
 
     ($call:ident! $extra:tt $b1:tt [ $($inner:tt)* ]) => {
-        $crate::pounded_var_names!($call! $extra $($inner)*);
+        $crate::pounded_var_names!{$call! $extra $($inner)*}
     };
 
     ($call:ident! $extra:tt $b1:tt { $($inner:tt)* }) => {
-        $crate::pounded_var_names!($call! $extra $($inner)*);
+        $crate::pounded_var_names!{$call! $extra $($inner)*}
     };
 
     ($call:ident!($($extra:tt)*) # $var:ident) => {
@@ -798,7 +798,7 @@ macro_rules! quote_bind_next_or_break {
 #[doc(hidden)]
 macro_rules! quote_each_token {
     ($tokens:ident $($tts:tt)*) => {
-        $crate::quote_tokens_with_context!($tokens
+        $crate::quote_tokens_with_context!{$tokens
             (@ @ @ @ @ @ $($tts)*)
             (@ @ @ @ @ $($tts)* @)
             (@ @ @ @ $($tts)* @ @)
@@ -806,7 +806,7 @@ macro_rules! quote_each_token {
             (@ @ $($tts)* @ @ @ @)
             (@ $($tts)* @ @ @ @ @)
             ($($tts)* @ @ @ @ @ @)
-        );
+        }
     };
 }
 
@@ -815,7 +815,7 @@ macro_rules! quote_each_token {
 #[doc(hidden)]
 macro_rules! quote_each_token_spanned {
     ($tokens:ident $span:ident $($tts:tt)*) => {
-        $crate::quote_tokens_with_context_spanned!($tokens $span
+        $crate::quote_tokens_with_context_spanned!{$tokens $span
             (@ @ @ @ @ @ $($tts)*)
             (@ @ @ @ @ $($tts)* @)
             (@ @ @ @ $($tts)* @ @)
@@ -823,7 +823,7 @@ macro_rules! quote_each_token_spanned {
             (@ @ $($tts)* @ @ @ @)
             (@ $($tts)* @ @ @ @ @)
             ($($tts)* @ @ @ @ @ @)
-        );
+        }
     };
 }
 
@@ -837,7 +837,7 @@ macro_rules! quote_tokens_with_context {
         ($($a1:tt)*) ($($a2:tt)*) ($($a3:tt)*)
     ) => {
         $(
-            $crate::quote_token_with_context!($tokens $b3 $b2 $b1 $curr $a1 $a2 $a3);
+            $crate::quote_token_with_context!{$tokens $b3 $b2 $b1 $curr $a1 $a2 $a3}
         )*
     };
 }
@@ -852,7 +852,7 @@ macro_rules! quote_tokens_with_context_spanned {
         ($($a1:tt)*) ($($a2:tt)*) ($($a3:tt)*)
     ) => {
         $(
-            $crate::quote_token_with_context_spanned!($tokens $span $b3 $b2 $b1 $curr $a1 $a2 $a3);
+            $crate::quote_token_with_context_spanned!{$tokens $span $b3 $b2 $b1 $curr $a1 $a2 $a3}
         )*
     };
 }
@@ -869,7 +869,7 @@ macro_rules! quote_token_with_context {
     ($tokens:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) * $a3:tt) => {{
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
-        $crate::pounded_var_names!(quote_bind_into_iter!(has_iter) () $($inner)*);
+        $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         let _: $crate::__private::HasIterator = has_iter;
         // This is `while true` instead of `loop` because if there are no
         // iterators used inside of this repetition then the body would not
@@ -878,8 +878,8 @@ macro_rules! quote_token_with_context {
         // fail to compile when there are no iterators, so here we just work
         // around the unneeded extra warning.
         while true {
-            $crate::pounded_var_names!(quote_bind_next_or_break!() () $($inner)*);
-            $crate::quote_each_token!($tokens $($inner)*);
+            $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
+            $crate::quote_each_token!{$tokens $($inner)*}
         }
     }};
     // ... and one step later.
@@ -892,15 +892,15 @@ macro_rules! quote_token_with_context {
         use $crate::__private::ext::*;
         let mut _i = 0usize;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
-        $crate::pounded_var_names!(quote_bind_into_iter!(has_iter) () $($inner)*);
+        $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         let _: $crate::__private::HasIterator = has_iter;
         while true {
-            $crate::pounded_var_names!(quote_bind_next_or_break!() () $($inner)*);
+            $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             if _i > 0 {
-                $crate::quote_token!($sep $tokens);
+                $crate::quote_token!{$sep $tokens}
             }
             _i += 1;
-            $crate::quote_each_token!($tokens $($inner)*);
+            $crate::quote_each_token!{$tokens $($inner)*}
         }
     }};
     // ... and one step later.
@@ -911,7 +911,7 @@ macro_rules! quote_token_with_context {
     // repetition symbol and the second `*` is treated as an ordinary token.)
     ($tokens:ident # ( $($inner:tt)* ) * (*) $a1:tt $a2:tt $a3:tt) => {
         // https://github.com/dtolnay/quote/issues/130
-        $crate::quote_token!(* $tokens);
+        $crate::quote_token!{* $tokens}
     };
     // ... and one step later.
     ($tokens:ident # ( $($inner:tt)* ) $sep:tt (*) $a1:tt $a2:tt $a3:tt) => {};
@@ -925,7 +925,7 @@ macro_rules! quote_token_with_context {
 
     // An ordinary token, not part of any interpolation.
     ($tokens:ident $b3:tt $b2:tt $b1:tt ($curr:tt) $a1:tt $a2:tt $a3:tt) => {
-        $crate::quote_token!($curr $tokens);
+        $crate::quote_token!{$curr $tokens}
     };
 }
 
@@ -939,11 +939,11 @@ macro_rules! quote_token_with_context_spanned {
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) * $a3:tt) => {{
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
-        $crate::pounded_var_names!(quote_bind_into_iter!(has_iter) () $($inner)*);
+        $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         let _: $crate::__private::HasIterator = has_iter;
         while true {
-            $crate::pounded_var_names!(quote_bind_next_or_break!() () $($inner)*);
-            $crate::quote_each_token_spanned!($tokens $span $($inner)*);
+            $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
+            $crate::quote_each_token_spanned!{$tokens $span $($inner)*}
         }
     }};
     ($tokens:ident $span:ident $b3:tt $b2:tt # (( $($inner:tt)* )) * $a2:tt $a3:tt) => {};
@@ -953,22 +953,22 @@ macro_rules! quote_token_with_context_spanned {
         use $crate::__private::ext::*;
         let mut _i = 0usize;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
-        $crate::pounded_var_names!(quote_bind_into_iter!(has_iter) () $($inner)*);
+        $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         let _: $crate::__private::HasIterator = has_iter;
         while true {
-            $crate::pounded_var_names!(quote_bind_next_or_break!() () $($inner)*);
+            $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             if _i > 0 {
-                $crate::quote_token_spanned!($sep $tokens $span);
+                $crate::quote_token_spanned!{$sep $tokens $span}
             }
             _i += 1;
-            $crate::quote_each_token_spanned!($tokens $span $($inner)*);
+            $crate::quote_each_token_spanned!{$tokens $span $($inner)*}
         }
     }};
     ($tokens:ident $span:ident $b3:tt $b2:tt # (( $($inner:tt)* )) $sep:tt * $a3:tt) => {};
     ($tokens:ident $span:ident $b3:tt # ( $($inner:tt)* ) ($sep:tt) * $a2:tt $a3:tt) => {};
     ($tokens:ident $span:ident # ( $($inner:tt)* ) * (*) $a1:tt $a2:tt $a3:tt) => {
         // https://github.com/dtolnay/quote/issues/130
-        $crate::quote_token_spanned!(* $tokens $span);
+        $crate::quote_token_spanned!{* $tokens $span}
     };
     ($tokens:ident $span:ident # ( $($inner:tt)* ) $sep:tt (*) $a1:tt $a2:tt $a3:tt) => {};
 
@@ -978,7 +978,7 @@ macro_rules! quote_token_with_context_spanned {
     ($tokens:ident $span:ident $b3:tt $b2:tt # ($var:ident) $a1:tt $a2:tt $a3:tt) => {};
 
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt ($curr:tt) $a1:tt $a2:tt $a3:tt) => {
-        $crate::quote_token_spanned!($curr $tokens $span);
+        $crate::quote_token_spanned!{$curr $tokens $span}
     };
 }
 


### PR DESCRIPTION
Look at <kbd>cargo rustc --profile=check -- -Zunpretty=expanded</kbd> of the following program:

```rust
use quote::quote;

fn main() {
    let _ = quote!(1 + 1);
}
```

### Before:

```rust
use quote::quote;

fn main() {
    let _ =
        {
            let mut _s = ::quote::__private::TokenStream::new();
            ;
            ;
            ;
            ::quote::__private::parse(&mut _s, "1");
            ;
            ::quote::__private::push_add(&mut _s);
            ;
            ::quote::__private::parse(&mut _s, "1");
            ;
            ;
            ;
            ;
            _s
        };
}
```

### After:

```rust
use quote::quote;

fn main() {
    let _ =
        {
            let mut _s = ::quote::__private::TokenStream::new();
            ::quote::__private::parse(&mut _s, "1");
            ::quote::__private::push_add(&mut _s);
            ::quote::__private::parse(&mut _s, "1");
            _s
        };
}
```