### PR TITLE
Disable the invalid span workaround in spanned.rs on patched versions of rustc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::process::{self, Command};
+use std::str;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let version = match rustc_version() {
+        Some(version) => version,
+        None => return,
+    };
+
+    if version.minor < 31 {
+        eprintln!("Minimum supported rustc version is 1.31");
+        process::exit(1);
+    }
+
+    if version.minor < 53 {
+        println!("cargo:rustc-cfg=needs_invalid_span_workaround");
+    }
+}
+
+struct RustcVersion {
+    minor: u32,
+}
+
+fn rustc_version() -> Option<RustcVersion> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    let minor = pieces.next()?.parse().ok()?;
+    Some(RustcVersion { minor })
+}

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -18,10 +18,11 @@ impl<T: ?Sized + ToTokens> Spanned for T {
 }
 
 fn join_spans(tokens: TokenStream) -> Span {
+    #[cfg(not(needs_invalid_span_workaround))]
+    let mut iter = tokens.into_iter().map(|tt| tt.span());
+
+    #[cfg(needs_invalid_span_workaround)]
     let mut iter = tokens.into_iter().filter_map(|tt| {
-        // FIXME: This shouldn't be required, since optimally spans should
-        // never be invalid. This filter_map can probably be removed when
-        // https://github.com/rust-lang/rust/issues/43081 is resolved.
         let span = tt.span();
         let debug = format!("{:?}", span);
         if debug.ends_with("bytes(0..0)") {


### PR DESCRIPTION
Fixes #222