### PR TITLE
Use Ident::new_raw to quote raw identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autobenches = false
 rust-version = "1.31"
 
 [dependencies]
-proc-macro2 = { version = "1.0.36", default-features = false }
+proc-macro2 = { version = "1.0.40", default-features = false }
 
 [dev-dependencies]
 rustversion = "1.0"


### PR DESCRIPTION
This requires the changes in https://github.com/dtolnay/proc-macro2/pull/331 which expose Ident::new_raw from proc-macro2, along with providing a fallback for earlier versions of Rust. Marking as a draft until that's ready.

Fixes #223