### PR TITLE
Call `format!` through an unambiguous path

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -129,7 +129,10 @@ macro_rules! format_ident {
 macro_rules! format_ident_impl {
     // Final state
     ([$span:expr, $($fmt:tt)*]) => {
-        $crate::__private::mk_ident(&format!($($fmt)*), $span)
+        $crate::__private::mk_ident(
+            &$crate::__private::format!($($fmt)*),
+            $span,
+        )
     };
 
     // Span argument

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@ use std::iter;
 use std::ops::BitOr;
 
 pub use proc_macro2::*;
+pub use std::format;
 
 pub struct HasIterator; // True
 pub struct ThereIsNoIteratorInRepetition; // False


### PR DESCRIPTION
Repro:

```rust
use quote::format_ident;

macro_rules! format {
    () => {};
}

fn main() {
    let _ = format_ident!("foo");
}
```

Previously:

```console
error: no rules expected the token `"foo"`
 --> src/main.rs:8:13
  |
3 | macro_rules! format {
  | ------------------- when calling this macro
...
8 |     let _ = format_ident!("foo");
  |             ^^^^^^^^^^^^^^^^^^^^ no rules expected this token in macro call
  |
  = note: this error originates in the macro `format_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
```