### PR TITLE
Interpolate blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,6 +953,18 @@ macro_rules! quote_token_with_context {
     // ... and one step later.
     ($tokens:ident $b3:tt $b2:tt # ($var:ident) $a1:tt $a2:tt $a3:tt) => {};
 
+    // a block interpolation
+    ($tokens:ident $b3:tt $b2:tt $b1:tt (#) @ { $($inner:tt)* } @) => {{
+        use $crate::ToTokens;
+        $crate::__private::BlockInterp({ $($inner)* }).to_tokens(&mut $tokens);
+    }};
+    // ... and one step later.
+    ($tokens:ident $b3:tt $b2:tt # (@) { $($inner:tt)* } @ $a3:tt) => {};
+    // ... and one step later.
+    ($tokens:ident $b3:tt # @ ({ $($inner:tt)* }) @ $a2:tt $a3:tt) => {};
+    // ... and one step later.
+    ($tokens:ident # @ { $($inner:tt)* } (@) $a1:tt $a2:tt $a3:tt) => {};
+
     // An ordinary token, not part of any interpolation.
     ($tokens:ident $b3:tt $b2:tt $b1:tt ($curr:tt) $a1:tt $a2:tt $a3:tt) => {
         $crate::quote_token!{$curr $tokens}
@@ -1006,6 +1018,14 @@ macro_rules! quote_token_with_context_spanned {
         $crate::ToTokens::to_tokens(&$var, &mut $tokens);
     };
     ($tokens:ident $span:ident $b3:tt $b2:tt # ($var:ident) $a1:tt $a2:tt $a3:tt) => {};
+
+    ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) @ { $($inner:tt)* } @) => {{
+        use $crate::ToTokens;
+        $crate::__private::BlockInterp({ $($inner)* }).to_tokens(&mut $tokens);
+    }};
+    ($tokens:ident $span:ident $b3:tt $b2:tt # (@) { $($inner:tt)* } @ $a3:tt) => {};
+    ($tokens:ident $span:ident $b3:tt # @ ({ $($inner:tt)* }) @ $a2:tt $a3:tt) => {};
+    ($tokens:ident $span:ident # @ { $($inner:tt)* } (@) $a1:tt $a2:tt $a3:tt) => {};
 
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt ($curr:tt) $a1:tt $a2:tt $a3:tt) => {
         $crate::quote_token_spanned!{$curr $tokens $span}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -181,6 +181,36 @@ impl<T: ToTokens> ToTokens for RepInterp<T> {
     }
 }
 
+impl<T> core::ops::Deref for RepInterp<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Helper type used within interpolations to allow output of
+// both one `ToTokens` and an iterator of `ToTokens`.
+#[derive(Copy, Clone)]
+#[doc(hidden)]
+pub struct BlockInterp<T>(pub T);
+
+impl<T: ToTokens, I: Iterator<Item = T>> BlockInterp<I> {
+    // This method shallows `ToTokens::to_tokens` when the output of
+    // the block to be interpolated is an iterator of `ToTokens`.
+    pub fn to_tokens(self, tokens: &mut TokenStream) {
+        for item in self.0 {
+            item.to_tokens(tokens);
+        }
+    }
+}
+
+impl<T: ToTokens> ToTokens for BlockInterp<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens);
+    }
+}
+
 #[doc(hidden)]
 #[inline]
 pub fn get_span<T>(span: T) -> GetSpan<T> {

--- a/tests/block_test.rs
+++ b/tests/block_test.rs
@@ -1,0 +1,346 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{format_ident, quote, quote_spanned};
+
+#[test]
+fn test_quote_not_block() {
+    // ensure "foo" is not executed
+    let _ = quote! {
+        #{ foo }
+        #@{ foo }#
+        #{ foo }@
+        @{ foo }@
+    };
+}
+
+#[test]
+fn test_quote_block() {
+    let variants = vec![quote! { A }, quote! { B }, quote! { C }];
+
+    let tokens = quote! {
+        match x { #@{
+            variants.iter().enumerate().map(|(i, v)| {
+                quote! { Self::#v => #i, }
+            })
+        }@ }
+    };
+
+    let expected = concat!(
+        "match x { ",
+        "Self :: A => 0usize , ",
+        "Self :: B => 1usize , ",
+        "Self :: C => 2usize , ",
+        "}"
+    );
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_expressions() {
+    let a = quote! { test_a };
+    let b = quote! { test_b };
+    let c = quote! { test_c };
+    let v = vec![&a, &b, &c];
+
+    let tokens = quote! {
+        #a
+        #@{ v[0] }@
+        #b
+        #@{ v[1] }@
+        #c
+    };
+
+    let expected = "test_a test_a test_b test_b test_c";
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_expressions_chaining() {
+    let a = quote! { test_a };
+    let b = quote! { test_b };
+    let c = quote! { test_c };
+    let v = vec![&a, &b, &c];
+
+    let tokens = quote! {
+        #a
+        #@{ v[0] }@
+        #b
+        #@{ v[1] }@
+        #c
+    };
+
+    let expected = "test_a test_a test_b test_b test_c";
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_spanned() {
+    let x = 42;
+    let span = Span::call_site();
+    let tokens = quote_spanned! { span =>
+        #@{
+            if x == 42 {
+                quote_spanned! { span => true }
+            } else {
+                quote_spanned! { span => false }
+            }
+        }@
+    };
+    assert_eq!("true", tokens.to_string());
+    let tokens = quote! {
+        #@{
+            if x != 42 {
+                quote_spanned! { span => true }
+            } else {
+                quote_spanned! { span => false }
+            }
+        }@
+    };
+    assert_eq!("false", tokens.to_string());
+    let tokens = quote! {
+        #@{
+            if x - 42 == 0 {
+                quote! { true }
+            } else {
+                quote_spanned! { span => false }
+            }
+        }@
+    };
+    assert_eq!("true", tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_with_ident() {
+    let variants = vec![quote! { A }, quote! { B }, quote! { C }];
+
+    let before = quote! { do_before() };
+    let call = quote! { do_foo };
+    let after = quote! { do_after() };
+
+    let tokens = quote! {
+        #before
+        #@{
+            let mut t = TokenStream::new();
+            for v in variants {
+                t.extend(quote! { #call(#v); });
+            }
+            t
+        }@
+        #after
+    };
+
+    let expected = concat!(
+        "do_before () ",
+        "do_foo (A) ; do_foo (B) ; do_foo (C) ; ",
+        "do_after ()"
+    );
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_nested_simple() {
+    let foo = quote! { foo };
+    let bar = quote! { bar };
+
+    let tokens = quote! {
+        #@{
+            quote!{ #foo #bar }
+        }@
+    };
+    let expected = "foo bar";
+    assert_eq!(expected, tokens.to_string());
+
+    let tokens = quote! {
+        #foo
+        #@{
+            quote!{ #foo #@{ quote!{ #foo #bar } }@ #bar }
+        }@
+        #bar
+    };
+    let expected = "foo foo foo bar bar bar";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_nested() {
+    let structs = vec![
+        (
+            quote! { StructA },
+            vec![quote! { foo }, quote! { bar }],
+            vec![quote! { FieldA1 }, quote! { FieldA2 }],
+        ),
+        (
+            quote! { StructB },
+            vec![quote! { foo }, quote! { bar }, quote! { baz }],
+            vec![quote! { FieldB1 }, quote! { FieldB2 }, quote! { FieldB3 }],
+        ),
+        (quote! { StructC }, vec![], vec![]),
+    ];
+
+    let mod_ident = quote! { block_test };
+
+    let tokens = quote! {
+        mod #mod_ident { #@{
+            structs.iter().map(|(s, f, f_ty)| {
+                quote! {
+                    struct #s {
+                        #@{ {{ // these braces should have no effect, just making sure the matching
+                            // works
+                            std::iter::zip(f.iter(), f_ty.iter()).map(|(f, f_ty)| {
+                                quote! { #f: #f_ty, }
+                            })
+                        }} }@
+                    }
+                }
+            })
+        }@ }
+    };
+
+    let expected = concat!(
+        "mod block_test { ",
+        "struct StructA { foo : FieldA1 , bar : FieldA2 , } ",
+        "struct StructB { foo : FieldB1 , bar : FieldB2 , baz : FieldB3 , } ",
+        "struct StructC { } ",
+        "}"
+    );
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_fn_call() {
+    let lits = ["a", "b", "c"];
+    fn make_my_ident(lit: &str) -> Ident {
+        format_ident!("my_ident_{}", lit)
+    }
+    let tokens = quote! {
+        #@{ make_my_ident("foo") }@
+        #@{
+            lits.iter().map(|x| make_my_ident(*x))
+        }@
+        #@{ make_my_ident("bar") }@
+    };
+
+    let expected = "my_ident_foo my_ident_a my_ident_b my_ident_c my_ident_bar";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_with_iter() {
+    let lits = vec![quote! { a }, quote! { b }, quote! { c }];
+
+    let tokens = quote! {
+        #( invoke( #lits ); )*
+        #@{ lits.iter() }@
+        #@{ lits.iter().map(|x| quote! { invoke(#x) }) }@
+    };
+
+    let expected = concat!(
+        "invoke (a) ; invoke (b) ; invoke (c) ; ",
+        "a b c ",
+        "invoke (a) invoke (b) invoke (c)"
+    );
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_nested_iter() {
+    let a = quote! { a };
+    let b = quote! { b };
+    let c = quote! { c };
+    let ids = [&a, &b, &c];
+
+    let tokens = quote! {
+        #(
+            invoke(#ids);
+            #@{
+                quote!{#ids}.to_string()
+            }@
+            #c
+        )*
+    };
+
+    let expected = concat!(
+        "invoke (a) ; ",
+        "\"a\" ",
+        "c ",
+        "invoke (b) ; ",
+        "\"b\" ",
+        "c ",
+        "invoke (c) ; ",
+        "\"c\" ",
+        "c",
+    );
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_surround_regular_block() {
+    let ident = quote! { my_ident };
+
+    let tokens = quote! {
+        { hello }#@
+        {
+            Ident::new("mystery", Span::call_site())
+        }
+        @{ world }#
+        ident
+    };
+
+    let expected = "{ hello } mystery { world } my_ident";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_many_nesting() {
+    let a = quote! { a };
+    let b = quote! { b };
+    let ids = vec![&a, &b];
+    let ids2 = vec![vec![&a, &b], vec![&b, &a]];
+
+    let tokens = quote! {
+        #(
+            invoke(#ids);
+            #@{
+                quote! { #( #@{ quote!(#ids) }@ (#ids2); )* }
+            }@
+        )*
+    };
+
+    let expected = concat!(
+        "invoke (a) ; ",
+        "a (a) ; a (b) ; ",
+        "invoke (b) ; ",
+        "b (b) ; b (a) ;"
+    );
+
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_quote_block_bind_iter() {
+    let a = quote! { a };
+    let b = quote! { b };
+    let ids2 = vec![vec![&a, &b], vec![&b, &a]];
+
+    let tokens = quote! {
+        #(
+            invoke(#(#ids2),*);
+            #@{
+                let mut t = TokenStream::new();
+                t.extend(ids2[0].clone());
+                t.extend(quote! { + });
+                t.extend(ids2[1].clone());
+                t
+            }@
+        )*
+    };
+
+    let expected = "invoke (a , b) ; a + b invoke (b , a) ; b + a";
+
+    assert_eq!(expected, tokens.to_string());
+}


### PR DESCRIPTION
This is my design/attempt at implementing #275 

## Proposed Syntax
I spent a lot of time thinking about what the syntax should be. IMO, it should:
1. Compatible with existing syntax and design language (i.e. use `#` to indicate interpolation)
2. Allow users to easily tell if a block is quoted vs interpolated
3. Allow users to easily tell where the start and end of that block is
4. Be intuitive and does not invent a very different syntax
5. Does not introduce ambiguity or tricky edge cases

I started with `#{ ... }`, went though many iterations and in the end settled on `#@{ ... }@`:
- It uses `#` to indicate start interpolating, which is consistent with other interpolation pattern
- `@` and `{}` are commonly used for interpolation
- It doesn't have edge cases like chaining the end of a block into the start of another

## Proposed Behavior
There are 2 ways where this could be implemented, with different behaviors:
1. A separated pass to extract all interpolation block, and execute them before the second pass to process idents and repetitions
2. Still keep the single pass design, and execute the block where it's at and add the output to the running `TokenStream`

I chose 2 since the implementation is way simpler, and probably more intuitive when composed with `#( ... )*`. This implementation also allows the blocks to access the bindings generated by `#( ... )*`, which becomes useful if we make `RepInterp` implement `Deref`. Just a dummy example:
```rust
let a = quote! { a };
let b = quote! { b };
let ids2 = vec![ vec![&a, &b], vec![&b, &a] ];

let tokens = quote! {
    #(
        invoke(#(#ids2),*);
        #@{
            let mut t = TokenStream::new();
            t.extend(ids2[0].clone());
            t.extend(quote! { + });
            t.extend(ids2[1].clone());
            t
        }@
    )*
};
// output: invoke (a, b) ; a + b invoke (b, a) ; b + a
```

Also, for ergonomic reasons, it's ideal for the macro to handle both when the block outputs a `ToTokens` or an iterator of them. This is implemented with a same trick used for repetition where a `to_tokens` method shadows the trait method if the trait is not implemented

## Other
- Any issue/edge case with the syntax?
- Any issue with implementing `Deref` for `RepInterp`?

Please let me know if there are other concerns

Tasks
---
- [x] Design
- [x] Tests
- [x] Implementation
- [ ] Update documentation
- [ ] Compile fail tests