### PR TITLE
Combine char's ToTokens impl with numeric primitives

### DIFF
--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -153,12 +153,8 @@ primitive! {
 
     f32 => f32_suffixed
     f64 => f64_suffixed
-}
 
-impl ToTokens for char {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Literal::character(*self));
-    }
+    char => character
 }
 
 impl ToTokens for bool {


### PR DESCRIPTION
Having the char impl separate used to be necessary briefly between https://github.com/dtolnay/quote/commit/2cd9e39fee63be1e1ccac3218cb2b948e079cb6b and https://github.com/dtolnay/quote/commit/0f60738c5a58b0b0dea2e8ce98616ba2016b127a.