### PR TITLE
Consistently use `tokens` as the name of the &mut TokenStream arg

### DIFF
--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -189,14 +189,14 @@ impl ToTokens for Literal {
 }
 
 impl ToTokens for TokenTree {
-    fn to_tokens(&self, dst: &mut TokenStream) {
-        dst.append(self.clone());
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(self.clone());
     }
 }
 
 impl ToTokens for TokenStream {
-    fn to_tokens(&self, dst: &mut TokenStream) {
-        dst.extend(iter::once(self.clone()));
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(iter::once(self.clone()));
     }
 
     fn into_token_stream(self) -> TokenStream {


### PR DESCRIPTION
It is not clear why this pair of impls was done differently in https://github.com/dtolnay/quote/commit/dd5f645c8bf337c18f0872b4018a10c91b02cad1.