### PR TITLE
Implement ToTokens for CStr and CString

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/dtolnay/quote"
 rust-version = "1.56"
 
 [dependencies]
-proc-macro2 = { version = "1.0.74", default-features = false }
+proc-macro2 = { version = "1.0.80", default-features = false }
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -3,6 +3,7 @@ use alloc::borrow::Cow;
 use alloc::rc::Rc;
 use core::iter;
 use proc_macro2::{Group, Ident, Literal, Punct, Span, TokenStream, TokenTree};
+use std::ffi::{CStr, CString};
 
 /// Types that can be interpolated inside a `quote!` invocation.
 ///
@@ -218,6 +219,18 @@ impl ToTokens for bool {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let word = if *self { "true" } else { "false" };
         tokens.append(Ident::new(word, Span::call_site()));
+    }
+}
+
+impl ToTokens for CStr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Literal::c_string(self));
+    }
+}
+
+impl ToTokens for CString {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Literal::c_string(self));
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,6 +12,7 @@ use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, TokenStreamExt};
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::ffi::{CStr, CString};
 
 struct X;
 
@@ -229,6 +230,22 @@ fn test_string() {
     let s = "\u{1} a 'b \" c".to_string();
     let tokens = quote!(#s);
     let expected = "\"\\u{1} a 'b \\\" c\"";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_c_str() {
+    let s = CStr::from_bytes_with_nul(b"\x01 a 'b \" c\0").unwrap();
+    let tokens = quote!(#s);
+    let expected = "c\"\\u{1} a 'b \\\" c\"";
+    assert_eq!(expected, tokens.to_string());
+}
+
+#[test]
+fn test_c_string() {
+    let s = CString::new(&b"\x01 a 'b \" c"[..]).unwrap();
+    let tokens = quote!(#s);
+    let expected = "c\"\\u{1} a 'b \\\" c\"";
     assert_eq!(expected, tokens.to_string());
 }
 

--- a/tests/ui/not-quotable.stderr
+++ b/tests/ui/not-quotable.stderr
@@ -11,10 +11,10 @@ error[E0277]: the trait bound `Ipv4Addr: ToTokens` is not satisfied
             &'a T
             &'a mut T
             Box<T>
+            CStr
+            CString
             Cow<'a, T>
             Option<T>
             Rc<T>
-            RepInterp<T>
-            String
           and $N others
   = note: this error originates in the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
These call the new `Literal::c_string` constructor from https://github.com/dtolnay/proc-macro2/pull/450.