### PR TITLE
refactor: push_lifetime* goes through an array instead of a manual iterator

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -314,7 +314,11 @@ pub fn push_lifetime(tokens: &mut TokenStream, lifetime: &str) {
 #[doc(hidden)]
 pub fn push_lifetime_spanned(tokens: &mut TokenStream, span: Span, lifetime: &str) {
     tokens.extend([
-        TokenTree::Punct(Punct::new('\'', Spacing::Joint)),
+        TokenTree::Punct({
+            let mut tick = Punct::new('\'', Spacing::Joint);
+            tick.set_span(span);
+            tick
+        }),
         TokenTree::Ident(Ident::new(&lifetime[1..], span)),
     ]);
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -305,68 +305,18 @@ pub fn push_ident_spanned(tokens: &mut TokenStream, span: Span, s: &str) {
 
 #[doc(hidden)]
 pub fn push_lifetime(tokens: &mut TokenStream, lifetime: &str) {
-    struct Lifetime<'a> {
-        name: &'a str,
-        state: u8,
-    }
-
-    impl<'a> Iterator for Lifetime<'a> {
-        type Item = TokenTree;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            match self.state {
-                0 => {
-                    self.state = 1;
-                    Some(TokenTree::Punct(Punct::new('\'', Spacing::Joint)))
-                }
-                1 => {
-                    self.state = 2;
-                    Some(TokenTree::Ident(Ident::new(self.name, Span::call_site())))
-                }
-                _ => None,
-            }
-        }
-    }
-
-    tokens.extend(Lifetime {
-        name: &lifetime[1..],
-        state: 0,
-    });
+    tokens.extend([
+        TokenTree::Punct(Punct::new('\'', Spacing::Joint)),
+        TokenTree::Ident(Ident::new(&lifetime[1..], Span::call_site())),
+    ]);
 }
 
 #[doc(hidden)]
 pub fn push_lifetime_spanned(tokens: &mut TokenStream, span: Span, lifetime: &str) {
-    struct Lifetime<'a> {
-        name: &'a str,
-        span: Span,
-        state: u8,
-    }
-
-    impl<'a> Iterator for Lifetime<'a> {
-        type Item = TokenTree;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            match self.state {
-                0 => {
-                    self.state = 1;
-                    let mut apostrophe = Punct::new('\'', Spacing::Joint);
-                    apostrophe.set_span(self.span);
-                    Some(TokenTree::Punct(apostrophe))
-                }
-                1 => {
-                    self.state = 2;
-                    Some(TokenTree::Ident(Ident::new(self.name, self.span)))
-                }
-                _ => None,
-            }
-        }
-    }
-
-    tokens.extend(Lifetime {
-        name: &lifetime[1..],
-        span,
-        state: 0,
-    });
+    tokens.extend([
+        TokenTree::Punct(Punct::new('\'', Spacing::Joint)),
+        TokenTree::Ident(Ident::new(&lifetime[1..], span)),
+    ]);
 }
 
 macro_rules! push_punct {


### PR DESCRIPTION
This should be faster:
```console
$ cargo bench --bench token-iteration --quiet -- --min-time 10
Timer precision: 25 ns
token_iteration  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ bench                       │               │               │               │         │
   ├─ array      143.8 ns      │ 11.52 ms      │ 149.8 ns      │ 169.7 ns      │ 29596510 │ 29596510
   ╰─ manual     162.8 ns      │ 19.56 ms      │ 168.8 ns      │ 190.3 ns      │ 28223255 │ 28223255
```
<details>
<summary>
Benchmark source
</summary>

```rust
use core::fmt;

use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream, TokenTree};

fn main() {
    divan::main();
}

#[derive(Clone, Copy)]
enum Method {
    Array,
    Manual,
}

impl fmt::Display for Method {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        f.write_str(match self {
            Method::Array => "array",
            Method::Manual => "manual",
        })
    }
}

#[divan::bench(args = [Method::Array, Method::Manual])]
fn bench(method: Method) {
    let mut tokens = TokenStream::new();
    let lifetime = "'lifetime";

    match method {
        Method::Array => {
            tokens.extend([
                TokenTree::Punct(Punct::new('\'', Spacing::Joint)),
                TokenTree::Ident(Ident::new(&lifetime[1..], Span::call_site())),
            ]);
        }
        Method::Manual => {
            struct Lifetime<'a> {
                name: &'a str,
                state: u8,
            }

            impl Iterator for Lifetime<'_> {
                type Item = TokenTree;

                fn next(&mut self) -> Option<Self::Item> {
                    match self.state {
                        0 => {
                            self.state = 1;
                            Some(TokenTree::Punct(Punct::new('\'', Spacing::Joint)))
                        }
                        1 => {
                            self.state = 2;
                            Some(TokenTree::Ident(Ident::new(self.name, Span::call_site())))
                        }
                        _ => None,
                    }
                }
            }

            tokens.extend(Lifetime {
                name: &lifetime[1..],
                state: 0,
            });
        }
    }
}
```
</details>

Shouldn't affect MSRV:
```console
$ rm Cargo.lock; cargo +1.56.1 test --quiet

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
i
test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 40 tests
........................................
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 22 tests
......................
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.99s
```