### PR TITLE
Feature: Add `const_quote` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1508,7 +1508,7 @@ macro_rules! const_quote {
             $vis struct $NAME;
 
             impl $crate::ToTokens for $NAME {
-                fn to_tokens(&self, _s: &mut proc_macro2::TokenStream) {
+                fn to_tokens(&self, _s: &mut $crate::__private::TokenStream) {
                     // TODO: skip creating unnecessary `TokenStream`
                     ($crate::quote! { $($tt)* })
                         .to_tokens(_s)


### PR DESCRIPTION
to define constant quote items like this:

```rust
const_quote! {
    pub const PATH_TO_MOD = {
        ::my_crate::path::to::module
    };

    pub const CALL_DEFAULT = {
        ::core::default::Default::default()
    };
}

fn use_constant() {
    let tokens = quote! {
        #PATH_TO_MOD::SomeType {
            field: value,
            ..#CALL_DEFAULT
        }
    };

    let expected = quote! {
        ::my_crate::path::to::module::SomeType {
            field: value,
            ..::core::default::Default::default()
        }
    };

    assert_eq!(tokens.to_string(), expected.to_string());
}
```