### PR TITLE
feat: advanced expression expansion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,6 +507,16 @@ __quote![
             $crate::ToTokens::to_tokens(&$var, &mut _s);
             _s
         }};
+
+        // Expression expansion such as #{object.field}
+        (# { $expr:expr }) => {{
+            let mut _s = $crate::__private::TokenStream::new();
+            #[doc(hidden)]
+            let __result = $expr;
+            $crate::ToTokens::to_tokens(&__result, &mut _s);
+            _s
+        }};
+
         ($tt1:tt $tt2:tt) => {{
             let mut _s = $crate::__private::TokenStream::new();
             $crate::quote_token!{$tt1 _s}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,7 @@
 extern crate proc_macro;
 
 use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream};
-use quote::{format_ident, quote, quote_spanned, TokenStreamExt};
+use quote::{format_ident, quote, quote_spanned, ToTokens, TokenStreamExt};
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::ffi::{CStr, CString};
@@ -565,4 +565,12 @@ fn test_type_inference_for_span() {
         let proc_macro_span = proc_macro::Span::call_site();
         let _ = quote_spanned!(proc_macro_span.into()=> ...);
     }
+}
+
+#[test]
+fn advanced_expression_expansion() {
+    let a = 1i32;
+    let b = 1i32;
+
+    assert_eq!(quote!{ #{a + b} }.to_string(), quote!{ 2i32 }.to_string())
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,7 @@
 extern crate proc_macro;
 
 use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream};
-use quote::{format_ident, quote, quote_spanned, ToTokens, TokenStreamExt};
+use quote::{format_ident, quote, quote_spanned, TokenStreamExt};
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::ffi::{CStr, CString};


### PR DESCRIPTION
# Advanced expression expansion
This PR allows the expansion of advanced expression instead of needing to make temporary variables.

In the case of storing context to a struct and needing to access it you no longer need to make a temporary variable and can directly do `quote!{ #{context.field} }`. This will directly expand to whatever tokens `context.field` had.

A test is implemented at the bottom of the `tests/test.rs` file.