### PR TITLE
Use diagnostic::on_unimplemented for checking iterator in repetition

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    if minor >= 77 {
+        println!("cargo:rustc-check-cfg=cfg(no_diagnostic_namespace)");
+    }
+
+    // Support for the `#[diagnostic]` tool attribute namespace
+    // https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#diagnostic-attributes
+    if minor < 78 {
+        println!("cargo:rustc-cfg=no_diagnostic_namespace");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,7 +888,7 @@ macro_rules! quote_token_with_context {
     // A repetition with no separator.
     ($tokens:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) * $a3:tt) => {{
         use $crate::__private::ext::*;
-        let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
+        let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         // This is `while true` instead of `loop` because if there are no
@@ -911,7 +911,7 @@ macro_rules! quote_token_with_context {
     ($tokens:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) $sep:tt *) => {{
         use $crate::__private::ext::*;
         let mut _i = 0usize;
-        let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
+        let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         while true {
@@ -958,7 +958,7 @@ macro_rules! quote_token_with_context_spanned {
 
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) * $a3:tt) => {{
         use $crate::__private::ext::*;
-        let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
+        let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         while true {
@@ -972,7 +972,7 @@ macro_rules! quote_token_with_context_spanned {
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) $sep:tt *) => {{
         use $crate::__private::ext::*;
         let mut _i = 0usize;
-        let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
+        let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         while true {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,7 +890,7 @@ macro_rules! quote_token_with_context {
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        let _: $crate::__private::HasIterator = has_iter;
+        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         // This is `while true` instead of `loop` because if there are no
         // iterators used inside of this repetition then the body would not
         // contain any `break`, so the compiler would emit unreachable code
@@ -913,7 +913,7 @@ macro_rules! quote_token_with_context {
         let mut _i = 0usize;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        let _: $crate::__private::HasIterator = has_iter;
+        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             if _i > 0 {
@@ -960,7 +960,7 @@ macro_rules! quote_token_with_context_spanned {
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        let _: $crate::__private::HasIterator = has_iter;
+        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             $crate::quote_each_token_spanned!{$tokens $span $($inner)*}
@@ -974,7 +974,7 @@ macro_rules! quote_token_with_context_spanned {
         let mut _i = 0usize;
         let has_iter = $crate::__private::ThereIsNoIteratorInRepetition;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        let _: $crate::__private::HasIterator = has_iter;
+        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             if _i > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,7 +890,7 @@ macro_rules! quote_token_with_context {
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
+        <_ as $crate::__private::CheckHasIterator<true>>::check(has_iter);
         // This is `while true` instead of `loop` because if there are no
         // iterators used inside of this repetition then the body would not
         // contain any `break`, so the compiler would emit unreachable code
@@ -913,7 +913,7 @@ macro_rules! quote_token_with_context {
         let mut _i = 0usize;
         let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
+        <_ as $crate::__private::CheckHasIterator<true>>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             if _i > 0 {
@@ -960,7 +960,7 @@ macro_rules! quote_token_with_context_spanned {
         use $crate::__private::ext::*;
         let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
+        <_ as $crate::__private::CheckHasIterator<true>>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             $crate::quote_each_token_spanned!{$tokens $span $($inner)*}
@@ -974,7 +974,7 @@ macro_rules! quote_token_with_context_spanned {
         let mut _i = 0usize;
         let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
-        <_ as $crate::__private::CheckHasIterator>::check(has_iter);
+        <_ as $crate::__private::CheckHasIterator<true>>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
             if _i > 0 {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,6 +49,10 @@ impl BitOr<HasIterator<true>> for HasIterator<true> {
 }
 
 #[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "repetition contains no interpolated value that is an iterator",
+    label = "none of the values interpolated inside this repetition are iterable"
+)]
 pub trait CheckHasIterator: Sized {
     fn check(self) {}
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,9 +49,12 @@ impl BitOr<HasIterator<true>> for HasIterator<true> {
 }
 
 #[doc(hidden)]
-#[diagnostic::on_unimplemented(
-    message = "repetition contains no interpolated value that is an iterator",
-    label = "none of the values interpolated inside this repetition are iterable"
+#[cfg_attr(
+    not(no_diagnostic_namespace),
+    diagnostic::on_unimplemented(
+        message = "repetition contains no interpolated value that is an iterator",
+        label = "none of the values interpolated inside this repetition are iterable"
+    )
 )]
 pub trait CheckHasIterator<const B: bool>: Sized {
     fn check(self) {}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -50,6 +50,13 @@ impl BitOr<HasIterator> for HasIterator {
     }
 }
 
+#[doc(hidden)]
+pub trait CheckHasIterator: Sized {
+    fn check(self) {}
+}
+
+impl CheckHasIterator for HasIterator {}
+
 /// Extension traits used by the implementation of `quote!`. These are defined
 /// in separate traits, rather than as a single trait due to ambiguity issues.
 ///

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -53,11 +53,11 @@ impl BitOr<HasIterator<true>> for HasIterator<true> {
     message = "repetition contains no interpolated value that is an iterator",
     label = "none of the values interpolated inside this repetition are iterable"
 )]
-pub trait CheckHasIterator: Sized {
+pub trait CheckHasIterator<const B: bool>: Sized {
     fn check(self) {}
 }
 
-impl CheckHasIterator for HasIterator<true> {}
+impl CheckHasIterator<true> for HasIterator<true> {}
 
 /// Extension traits used by the implementation of `quote!`. These are defined
 /// in separate traits, rather than as a single trait due to ambiguity issues.

--- a/tests/ui/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/does-not-have-iter-interpolated-dup.stderr
@@ -1,8 +1,9 @@
-error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
+error[E0277]: repetition contains no interpolated value that is an iterator
  --> tests/ui/does-not-have-iter-interpolated-dup.rs:8:5
   |
 8 |     quote!(#(#nonrep #nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
+  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/does-not-have-iter-interpolated-dup.stderr
@@ -4,6 +4,6 @@ error[E0277]: repetition contains no interpolated value that is an iterator
 8 |     quote!(#(#nonrep #nonrep)*);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
-  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
+  = help: the trait `CheckHasIterator<true>` is not implemented for `HasIterator<false>`
+          but it is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/does-not-have-iter-interpolated-dup.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
+error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter-interpolated-dup.rs:8:5
   |
 8 |     quote!(#(#nonrep #nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   |
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/does-not-have-iter-interpolated-dup.stderr
@@ -1,11 +1,8 @@
-error[E0308]: mismatched types
+error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter-interpolated-dup.rs:8:5
   |
 8 |     quote!(#(#nonrep #nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |     |
-  |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-  |     expected due to this
-  |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
   |
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/does-not-have-iter-interpolated.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
+error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter-interpolated.rs:8:5
   |
 8 |     quote!(#(#nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
+  |     ^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   |
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/does-not-have-iter-interpolated.stderr
@@ -4,6 +4,6 @@ error[E0277]: repetition contains no interpolated value that is an iterator
 8 |     quote!(#(#nonrep)*);
   |     ^^^^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
-  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
+  = help: the trait `CheckHasIterator<true>` is not implemented for `HasIterator<false>`
+          but it is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/does-not-have-iter-interpolated.stderr
@@ -1,11 +1,8 @@
-error[E0308]: mismatched types
+error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter-interpolated.rs:8:5
   |
 8 |     quote!(#(#nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^
-  |     |
-  |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-  |     expected due to this
-  |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
+  |     ^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
   |
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/does-not-have-iter-interpolated.stderr
@@ -1,8 +1,9 @@
-error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
+error[E0277]: repetition contains no interpolated value that is an iterator
  --> tests/ui/does-not-have-iter-interpolated.rs:8:5
   |
 8 |     quote!(#(#nonrep)*);
-  |     ^^^^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
+  |     ^^^^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
+  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-separated.stderr
+++ b/tests/ui/does-not-have-iter-separated.stderr
@@ -1,10 +1,8 @@
-error[E0308]: mismatched types
+error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter-separated.rs:4:5
   |
 4 |     quote!(#(a b),*);
-  |     ^^^^^^^^^^^^^^^^
-  |     |
-  |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-  |     expected due to this
+  |     ^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
   |
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-separated.stderr
+++ b/tests/ui/does-not-have-iter-separated.stderr
@@ -1,8 +1,9 @@
-error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
+error[E0277]: repetition contains no interpolated value that is an iterator
  --> tests/ui/does-not-have-iter-separated.rs:4:5
   |
 4 |     quote!(#(a b),*);
-  |     ^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
+  |     ^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
+  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-separated.stderr
+++ b/tests/ui/does-not-have-iter-separated.stderr
@@ -4,6 +4,6 @@ error[E0277]: repetition contains no interpolated value that is an iterator
 4 |     quote!(#(a b),*);
   |     ^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
-  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
+  = help: the trait `CheckHasIterator<true>` is not implemented for `HasIterator<false>`
+          but it is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter-separated.stderr
+++ b/tests/ui/does-not-have-iter-separated.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
+error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter-separated.rs:4:5
   |
 4 |     quote!(#(a b),*);
-  |     ^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
+  |     ^^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   |
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter.stderr
+++ b/tests/ui/does-not-have-iter.stderr
@@ -1,8 +1,9 @@
-error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
+error[E0277]: repetition contains no interpolated value that is an iterator
  --> tests/ui/does-not-have-iter.rs:4:5
   |
 4 |     quote!(#(a b)*);
-  |     ^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
+  |     ^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
+  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter.stderr
+++ b/tests/ui/does-not-have-iter.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
+error[E0277]: the trait bound `HasIterator<false>: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter.rs:4:5
   |
 4 |     quote!(#(a b)*);
-  |     ^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
+  |     ^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
   |
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter.stderr
+++ b/tests/ui/does-not-have-iter.stderr
@@ -4,6 +4,6 @@ error[E0277]: repetition contains no interpolated value that is an iterator
 4 |     quote!(#(a b)*);
   |     ^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
   |
-  = help: the trait `CheckHasIterator` is not implemented for `HasIterator<false>`
-  = help: the trait `CheckHasIterator` is implemented for `HasIterator<true>`
+  = help: the trait `CheckHasIterator<true>` is not implemented for `HasIterator<false>`
+          but it is implemented for `HasIterator<true>`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/does-not-have-iter.stderr
+++ b/tests/ui/does-not-have-iter.stderr
@@ -1,10 +1,8 @@
-error[E0308]: mismatched types
+error[E0277]: the trait bound `ThereIsNoIteratorInRepetition: CheckHasIterator` is not satisfied
  --> tests/ui/does-not-have-iter.rs:4:5
   |
 4 |     quote!(#(a b)*);
-  |     ^^^^^^^^^^^^^^^
-  |     |
-  |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-  |     expected due to this
+  |     ^^^^^^^^^^^^^^^ the trait `CheckHasIterator` is not implemented for `ThereIsNoIteratorInRepetition`
   |
+  = help: the trait `CheckHasIterator` is implemented for `HasIterator`
   = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Before:

```console
error[E0308]: mismatched types
 --> tests/ui/does-not-have-iter-interpolated.rs:8:5
  |
8 |     quote!(#(#nonrep)*);
  |     ^^^^^^^^^^^^^^^^^^^
  |     |
  |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
  |     expected due to this
  |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
  |
  = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
```

After:

```console
error[E0277]: repetition contains no interpolated value that is an iterator
 --> tests/ui/does-not-have-iter-interpolated.rs:8:5
  |
8 |     quote!(#(#nonrep)*);
  |     ^^^^^^^^^^^^^^^^^^^ none of the values interpolated inside this repetition are iterable
  |
  = help: the trait `CheckHasIterator<true>` is not implemented for `HasIterator<false>`
          but it is implemented for `HasIterator<true>`
  = note: this error originates in the macro `$crate::quote_token_with_context` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
```