### PR TITLE
Improve trait errors inside repetitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
     clippy::module_name_repetitions,
+    clippy::must_use_candidate,
     clippy::needless_lifetimes,
     // false positive https://github.com/rust-lang/rust-clippy/issues/6983
     clippy::wrong_self_convention,
@@ -728,9 +729,11 @@ macro_rules! pounded_var_with_context {
 #[doc(hidden)]
 macro_rules! quote_bind_into_iter {
     ($has_iter:ident $var:ident) => {
+        let kind = $crate::__private::GetQuoteKind(&$var).quote_kind();
+        $crate::__private::ext::ValidQuoteKind::check_quote(&kind);
         // `mut` may be unused if $var occurs multiple times in the list.
         #[allow(unused_mut)]
-        let (mut $var, i) = $var.quote_into_iter();
+        let (mut $var, i) = $var.quote_into_iter(kind);
         let $has_iter = $has_iter | i;
     };
 }

--- a/tests/ui/not-repeatable.stderr
+++ b/tests/ui/not-repeatable.stderr
@@ -1,42 +1,16 @@
-error[E0599]: the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not satisfied
+error[E0277]: type Ipv4Addr cannot be interpolated inside a repetition
  --> tests/ui/not-repeatable.rs:7:13
+  |
+7 |     let _ = quote! { #(#ip)* };
+  |             ^^^^^^^^^^^^^^^^^^
+  |             |
+  |             required by a bound introduced by this call
+  |
+help: the trait `Quote` is not implemented for `Ipv4Addr`
+ --> tests/ui/not-repeatable.rs:3:1
   |
 3 | struct Ipv4Addr;
-  | --------------- method `quote_into_iter` not found for this struct because it doesn't satisfy `Ipv4Addr: Iterator`, `Ipv4Addr: ToTokens`, `Ipv4Addr: ext::RepIteratorExt` or `Ipv4Addr: ext::RepToTokensExt`
-...
-7 |     let _ = quote! { #(#ip)* };
-  |             ^^^^^^^^^^^^^^^^^^ method cannot be called on `Ipv4Addr` due to unsatisfied trait bounds
-  |
-  = note: the following trait bounds were not satisfied:
-          `Ipv4Addr: Iterator`
-          which is required by `Ipv4Addr: ext::RepIteratorExt`
-          `&Ipv4Addr: Iterator`
-          which is required by `&Ipv4Addr: ext::RepIteratorExt`
-          `Ipv4Addr: ToTokens`
-          which is required by `Ipv4Addr: ext::RepToTokensExt`
-          `&mut Ipv4Addr: Iterator`
-          which is required by `&mut Ipv4Addr: ext::RepIteratorExt`
-note: the traits `Iterator` and `ToTokens` must be implemented
- --> $RUST/core/src/iter/traits/iterator.rs
-  |
-  | pub trait Iterator {
-  | ^^^^^^^^^^^^^^^^^^
-  |
- ::: src/to_tokens.rs
-  |
-  | pub trait ToTokens {
-  | ^^^^^^^^^^^^^^^^^^
-  = help: items from traits can only be used if the trait is implemented and in scope
-  = note: the following traits define an item `quote_into_iter`, perhaps you need to implement one of them:
-          candidate #1: `ext::RepAsIteratorExt`
-          candidate #2: `ext::RepIteratorExt`
-          candidate #3: `ext::RepToTokensExt`
+  | ^^^^^^^^^^^^^^^
+  = help: the trait `ValidQuoteKind` is implemented for `FallbackKind<T>`
+  = note: required for `FallbackKind<Ipv4Addr>` to implement `ValidQuoteKind`
   = note: this error originates in the macro `$crate::quote_bind_into_iter` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0282]: type annotations needed
- --> tests/ui/not-repeatable.rs:7:13
-  |
-7 |     let _ = quote! { #(#ip)* };
-  |             ^^^^^^^^^^^^^^^^^^ cannot infer type
-  |
-  = note: this error originates in the macro `$crate::quote_bind_next_or_break` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Before:

```console
error[E0599]: the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not satisfied
 --> tests/ui/not-repeatable.rs:7:13
  |
3 | struct Ipv4Addr;
  | --------------- method `quote_into_iter` not found for this struct because it doesn't satisfy `Ipv4Addr: Iterator`, `Ipv4Addr: ToTokens`, `Ipv4Addr: ext::RepIteratorExt` or `Ipv4Addr: ext::RepToTokensExt`
...
7 |     let _ = quote! { #(#ip)* };
  |             ^^^^^^^^^^^^^^^^^^ method cannot be called on `Ipv4Addr` due to unsatisfied trait bounds
  |
  = note: the following trait bounds were not satisfied:
          `Ipv4Addr: Iterator`
          which is required by `Ipv4Addr: ext::RepIteratorExt`
          `&Ipv4Addr: Iterator`
          which is required by `&Ipv4Addr: ext::RepIteratorExt`
          `Ipv4Addr: ToTokens`
          which is required by `Ipv4Addr: ext::RepToTokensExt`
          `&mut Ipv4Addr: Iterator`
          which is required by `&mut Ipv4Addr: ext::RepIteratorExt`
note: the traits `Iterator` and `ToTokens` must be implemented
 --> $RUST/core/src/iter/traits/iterator.rs
  |
  | pub trait Iterator {
  | ^^^^^^^^^^^^^^^^^^
  |
 ::: src/to_tokens.rs
  |
  | pub trait ToTokens {
  | ^^^^^^^^^^^^^^^^^^
  = help: items from traits can only be used if the trait is implemented and in scope
  = note: the following traits define an item `quote_into_iter`, perhaps you need to implement one of them:
          candidate #1: `ext::RepAsIteratorExt`
          candidate #2: `ext::RepIteratorExt`
          candidate #3: `ext::RepToTokensExt`
  = note: this error originates in the macro `$crate::quote_bind_into_iter` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0282]: type annotations needed
 --> tests/ui/not-repeatable.rs:7:13
  |
7 |     let _ = quote! { #(#ip)* };
  |             ^^^^^^^^^^^^^^^^^^ cannot infer type
  |
  = note: this error originates in the macro `$crate::quote_bind_next_or_break` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
```

After:

```console
error[E0277]: type Ipv4Addr cannot be interpolated inside a repetition
 --> tests/ui/not-repeatable.rs:7:13
  |
7 |     let _ = quote! { #(#ip)* };
  |             ^^^^^^^^^^^^^^^^^^
  |             |
  |             required by a bound introduced by this call
  |
help: the trait `Quote` is not implemented for `Ipv4Addr`
 --> tests/ui/not-repeatable.rs:3:1
  |
3 | struct Ipv4Addr;
  | ^^^^^^^^^^^^^^^
  = help: the trait `ValidQuoteKind` is implemented for `FallbackKind<T>`
  = note: required for `FallbackKind<Ipv4Addr>` to implement `ValidQuoteKind`
  = note: this error originates in the macro `$crate::quote_bind_into_iter` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
```