### PR TITLE
Exclude compile tests from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["macros", "syn"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/quote"
 rust-version = "1.60"
+include = ["src/**/*.rs", "build.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "tests/test.rs", "README.md"]
 
 [dependencies]
 proc-macro2 = { version = "1.0.80", default-features = false }


### PR DESCRIPTION
During a dependency review I noticed that quote includes the output of it's compile tests in the published package. These files are not required for building quote as dependency and make it a bit harder to review the code.

This commit introduces a `include` directive in the `Cargo.toml` file to explicitly include only those files required to build `quote`. This excludes the compile test artifacts and also reduces the size of the published crate from 35 files, 132.9KiB (30.7KiB compressed) to 16 files, 123.8KiB (28.1KiB compressed) which results in a 76GB/Month traffic reduction for crates.io assuming the current 31 million downloads and the difference in the compressed package size.

---

Removing the other test file would reduce the size to 15 files, 110.5KiB (25.3KiB compressed)