### PR TITLE
perf: less generic code in `TokenStreamExt::append()`

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -60,10 +60,10 @@ impl TokenStreamExt for TokenStream {
     where
         U: Into<TokenTree>,
     {
-        fn append_inner(stream: &mut TokenStream, tokens: TokenStream) {
-            stream.extend(tokens);
+        fn append_inner(stream: &mut TokenStream, tree: TokenTree) {
+            stream.extend(Some(tree));
         }
-        append_inner(self, TokenStream::from(token.into()));
+        append_inner(self, token.into());
     }
 
     fn append_all<I>(&mut self, iter: I)


### PR DESCRIPTION
Trick I found in https://github.com/dtolnay/syn/pull/1935

Before:
```
quote$ cargo llvm-lines --release --all-features --test test | head -n 3
  Lines                Copies             Function name
  -----                ------             -------------
  19299                478                (TOTAL)
```

After:
```
quote$ cargo llvm-lines --release --all-features --test test | head -n 3
  Lines                Copies             Function name
  -----                ------             -------------
  17846                430                (TOTAL)
```

