### PR TITLE
perf: monomorphize `TokenStreamExt::append_all` on `Iterator`

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -69,9 +69,16 @@ impl TokenStreamExt for TokenStream {
         I: IntoIterator,
         I::Item: ToTokens,
     {
-        for token in iter {
-            token.to_tokens(self);
+        fn append_all_inner<I>(stream: &mut TokenStream, iter: I)
+        where
+            I: Iterator,
+            I::Item: ToTokens,
+        {
+            for token in iter {
+                token.to_tokens(stream);
+            }
         }
+        append_all_inner(self, iter.into_iter());
     }
 
     fn append_separated<I, U>(&mut self, iter: I, op: U)


### PR DESCRIPTION
So this doesn't change llvm-lines in `quote`.

But `syn` uses `append_all`, so it is decresed by 187 lines

Before:
```
syn$ cargo llvm-lines --release --all-features | head -n 3
   Compiling quote v1.0.41 (../quote)
   Compiling syn v2.0.108 (./syn)
  Lines                 Copies              Function name
  -----                 ------              -------------
  221157                4748                (TOTAL)
```

After:
```
syn$ cargo llvm-lines --release --all-features | head -n 3
   Compiling quote v1.0.41 (../quote)
   Compiling syn v2.0.108 (./syn)
  Lines                 Copies              Function name
  -----                 ------              -------------
  220970                4726                (TOTAL)
```