### PR TITLE
perf: reduce llvm-lines by removing `.extend([_; 2])`

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -316,22 +316,21 @@ pub fn push_ident_spanned(tokens: &mut TokenStream, span: Span, s: &str) {
 
 #[doc(hidden)]
 pub fn push_lifetime(tokens: &mut TokenStream, lifetime: &str) {
-    tokens.extend([
-        TokenTree::Punct(Punct::new('\'', Spacing::Joint)),
-        TokenTree::Ident(Ident::new(&lifetime[1..], Span::call_site())),
-    ]);
+    tokens.append(TokenTree::Punct(Punct::new('\'', Spacing::Joint)));
+    tokens.append(TokenTree::Ident(Ident::new(
+        &lifetime[1..],
+        Span::call_site(),
+    )));
 }
 
 #[doc(hidden)]
 pub fn push_lifetime_spanned(tokens: &mut TokenStream, span: Span, lifetime: &str) {
-    tokens.extend([
-        TokenTree::Punct({
-            let mut apostrophe = Punct::new('\'', Spacing::Joint);
-            apostrophe.set_span(span);
-            apostrophe
-        }),
-        TokenTree::Ident(Ident::new(&lifetime[1..], span)),
-    ]);
+    tokens.append(TokenTree::Punct({
+        let mut apostrophe = Punct::new('\'', Spacing::Joint);
+        apostrophe.set_span(span);
+        apostrophe
+    }));
+    tokens.append(TokenTree::Ident(Ident::new(&lifetime[1..], span)));
 }
 
 macro_rules! push_punct {


### PR DESCRIPTION


Before:
```
quote$ cargo llvm-lines --release | head -n 3
  Lines               Copies             Function name
  -----               ------             -------------
  8959                447                (TOTAL)
```

After:
```
quote$ cargo llvm-lines --release | head -n 3
  Lines               Copies             Function name
  -----               ------             -------------
  8495                424                (TOTAL)
```