### PR TITLE
perf: reduce llvm-lines in quote! macro

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -96,10 +96,12 @@ impl TokenStreamExt for TokenStream {
             I::Item: ToTokens,
             U: ToTokens,
         {
-            for (i, token) in iter.into_iter().enumerate() {
-                if i > 0 {
+            let mut first = true;
+            for token in iter {
+                if !first {
                     op.to_tokens(stream);
                 }
+                first = false;
                 token.to_tokens(stream);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -911,16 +911,16 @@ macro_rules! quote_token_with_context {
     // A repetition with separator.
     ($tokens:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) $sep:tt *) => {{
         use $crate::__private::ext::*;
-        let mut _i = 0usize;
+        let mut _first = true;
         let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         <_ as $crate::__private::CheckHasIterator<true>>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
-            if _i > 0 {
+            if !_first {
                 $crate::quote_token!{$sep $tokens}
             }
-            _i += 1;
+            _first = false;
             $crate::quote_each_token!{$tokens $($inner)*}
         }
     }};
@@ -972,16 +972,16 @@ macro_rules! quote_token_with_context_spanned {
 
     ($tokens:ident $span:ident $b3:tt $b2:tt $b1:tt (#) ( $($inner:tt)* ) $sep:tt *) => {{
         use $crate::__private::ext::*;
-        let mut _i = 0usize;
+        let mut _first = true;
         let has_iter = $crate::__private::HasIterator::<false>;
         $crate::pounded_var_names!{quote_bind_into_iter!(has_iter) () $($inner)*}
         <_ as $crate::__private::CheckHasIterator<true>>::check(has_iter);
         while true {
             $crate::pounded_var_names!{quote_bind_next_or_break!() () $($inner)*}
-            if _i > 0 {
+            if !_first {
                 $crate::quote_token_spanned!{$sep $tokens $span}
             }
-            _i += 1;
+            _first = false;
             $crate::quote_each_token_spanned!{$tokens $span $($inner)*}
         }
     }};


### PR DESCRIPTION
Fixes #299

```
before /quote$ cargo llvm-lines --test test | head -n 3
  Lines                Copies             Function name
  -----                ------             -------------
  17727                462                (TOTAL)
 after /quote$ cargo llvm-lines --test test | head -n 3
  Lines                Copies             Function name
  -----                ------             -------------
  17682                462                (TOTAL)
```