### PR TITLE
Exclude Git(Hub) files from packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["macros", "syn"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/quote"
 rust-version = "1.68"
+exclude = ["/.github/", ".gitignore"]
 
 [dependencies]
 proc-macro2 = { version = "1.0.80", default-features = false }


### PR DESCRIPTION
The GitHub (CI) configuration and `.gitignore` aren't needed to build `quote`, and unlike the tests #304 aimed to exclude, I don't think they improve the reviewing experience.

Explicitly list the GitHub directory and any `.gitignore` file (technically including `.gitignore` files in subdirectories) in `Cargo.toml`'s `exclude` list.

Apologies if this has already been suggested before. I searched for relevant issues and PRs but only found PR 304.