### PR TITLE
Change std imports to core/alloc

### DIFF
--- a/src/to_tokens.rs
+++ b/src/to_tokens.rs
@@ -1,9 +1,10 @@
 use super::TokenStreamExt;
 use alloc::borrow::Cow;
+use alloc::ffi::CString;
 use alloc::rc::Rc;
+use core::ffi::CStr;
 use core::iter;
 use proc_macro2::{Group, Ident, Literal, Punct, Span, TokenStream, TokenTree};
-use std::ffi::{CStr, CString};
 
 /// Types that can be interpolated inside a `quote!` invocation.
 pub trait ToTokens {


### PR DESCRIPTION
See ae25ab6a5bde0efc79d85a8211b76d0bdd08dca7. CStr and CString are
available outside std since 1.64.0.
