### PR TITLE
tests: fix compilation with `--no-default-features`

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -561,6 +561,7 @@ fn test_type_inference_for_span() {
     let inferred = CallSite::get();
     let _ = quote_spanned!(inferred=> ...);
 
+    #[cfg(feature = "proc-macro")]
     if false {
         let proc_macro_span = proc_macro::Span::call_site();
         let _ = quote_spanned!(proc_macro_span.into()=> ...);


### PR DESCRIPTION
Before this change:
```
% cargo hack clippy --feature-powerset --all-targets
[...]
info: running `cargo clippy --all-targets --no-default-features` on quote (2/4)
    Checking quote v1.0.42 (/Users/tamird/src/quote)
error[E0277]: the trait bound `proc_macro2::Span: std::convert::From<proc_macro::Span>` is not satisfied
   --> tests/test.rs:566:48
    |
566 |         let _ = quote_spanned!(proc_macro_span.into()=> ...);
    |                                                ^^^^ the trait `std::convert::From<proc_macro::Span>` is not implemented for `proc_macro2::Span`
    |
    = note: required for `proc_macro::Span` to implement `std::convert::Into<proc_macro2::Span>`
```
