### PR TITLE
doc: restore link to `format!`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -4,7 +4,7 @@
 ///
 /// # Syntax
 ///
-/// Syntax is copied from the [`format_args!`] macro, supporting both positional
+/// Syntax is copied from the [`alloc::format!`] macro, supporting both positional
 /// and named arguments.
 ///
 /// Only a limited set of formatting traits are supported. The current mapping


### PR DESCRIPTION
Commit b3faa37cc505a90de54302413203804babd3ea6c changed this from
`format!` to `format_args!` because only the latter is in the core
prelude, but better to link to the more commonly used macro.
