### PR TITLE
chore: tag `format_ident` with `#[clippy::format_args]`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -108,6 +108,7 @@
 /// assert_eq!(upper_hex, "Id_A");
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! format_ident {
     ($fmt:expr) => {
         $crate::format_ident_impl!([


### PR DESCRIPTION
Since 1.85, Clippy supports `#[clippy::format_args]` attribute - see [docs](https://doc.rust-lang.org/clippy/attribs.html#clippyformat_args) - this way all users of this macro will get the benefits of clippy format arg validations.

The only possible problem is that `format_ident!("Foo{bar}")` might not be edition2021+ compliant (i.e. may treat that string as verbatim).  I suspect it might be ok to modify the macro implementation to always treat a single param macro as a format string because anything with curlies in it is not a valid identifier.

Fixes #290
Related #206